### PR TITLE
Audio-Only Bug if aborted with Ctr-C

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -252,7 +252,7 @@ play_url () {
 	[ -n "$YTFZF_PREF" ] && {
 		eval "$player_format""$YTFZF_PREF"  "$url"
 	} || {
-		eval "$player" "$url"
+		[ 4 -eq $? ] || eval "$player" "$url" # Ctr-C in MPV results in a return code of 4
 	} || {
 		printf "ERROR[#03]: Couldn't play the video/audio using the current player.\n\tTry updating youtube-dl\n"; errinfo ; save_before_exit ; exit 2;
 	}


### PR DESCRIPTION
If a Youtube video is started in the Audio-Only mode (`-m`), and then aborted with Ctr-C, the Video starts to play because the "else" branch is taken as of the return code being non-zero. I added a check if the return code is equal to 4 (The return value of MPV if the media stream is canceled with Ctr-C) to prevent that. There is probably a much cleaner way to do this ;-)
