### PR TITLE
Add flag to use ytfzf as yt-search

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -99,6 +99,7 @@ printf "     -f  <search query>    Show available formats before proceeding\n";
 printf "     -a  <search query>    Auto play the first result, no selector\n";
 printf "     -r  <search query>    Auto play a random result, no selector\n";
 printf "     -l  <search query>    Loop: prompt selector again after video ends\n";
+printf "     -L  <search query>    Prints the selected URL only, helpful for scripting\n";
 printf "  Use - instead of <query> for stdin\n";
 printf "\n"
 printf "  Option can be combines. Like\n"
@@ -199,6 +200,7 @@ preview_img () {
 
 # Opt variables
 show_thumbnails=0
+show_link_only=0
 main=0
 auto_select=0
 random_select=0
@@ -210,7 +212,7 @@ dep_ck () {
 dep_ck "jq"; dep_ck "youtube-dl"; dep_ck "mpv";
 
 # OPT
-while getopts "hDmdfxHarltU:" opt; do
+while getopts "LhDmdfxHarltU:" opt; do
 	case ${opt} in
 		h) 	helpinfo
 			exit;
@@ -248,6 +250,8 @@ while getopts "hDmdfxHarltU:" opt; do
 		l) 	YTFZF_LOOP=1
 			;;
 		t) 	show_thumbnails=1
+			;;
+		L) 	show_link_only=1
 			;;
 		U) 	[ -p "$FIFO" ] && preview_img "$OPTARG"; exit;
 			;;
@@ -340,6 +344,12 @@ user_selection () {
 	url="https://www.youtube.com/watch?v=$shorturl"
 	# to get back untruncated data
 	selected_data="$(echo "$videos_data" | grep -m1 -e "$shorturl" )"
+
+    if [ $show_link_only ] ; then
+      echo $url
+      exit
+    fi
+
 	# selecte format if flag given
 	[ $show_format -eq 1 ] && {
 		YTFZF_PREF="$(youtube-dl -F "$url" | sed '1,3d' | tac - |\

--- a/ytfzf
+++ b/ytfzf
@@ -145,20 +145,23 @@ download_thumbnails () {
 	thumb_urls="$(printf "%s" "$videos_json" |\
 		jq  '.thumbnail.thumbnails[0].url,.videoId' )"
 
-	printf "Downloading Thumbnails.."
+	if [ $show_link_only -eq 0 ]; then
+		printf "Downloading Thumbnails.."
+    fi
 	rm -r $thumb_dir/* 1>/dev/null 2>&1
 	i=0
 	while read line; do
 		[ $((i % 2)) -eq 0 ] && { url="$(echo $line | sed -E 's/^"//;s/\.png.*/\.png/')" ;}
 		[ $((i % 2)) -eq 1 ] && {
 			name="$(echo "$line" | tr -d '"')"
-			{ curl -s "$url" > "$thumb_dir/$name.png" && printf "."; } &
+			{ 
+              curl -s "$url" > "$thumb_dir/$name.png" && [ $show_link_only -eq 0 ] && printf "."; } &
 		}
 		i=$((i + 1))
 	done << EOF
 $thumb_urls
 EOF
-	wait && echo ""
+	wait && [ $show_link_only -eq 0 ] && echo ""
 
 }
 

--- a/ytfzf
+++ b/ytfzf
@@ -348,7 +348,7 @@ user_selection () {
 	# to get back untruncated data
 	selected_data="$(echo "$videos_data" | grep -m1 -e "$shorturl" )"
 
-    if [ $show_link_only ] ; then
+    if [ $show_link_only -eq 1 ] ; then
       echo $url
       exit
     fi


### PR DESCRIPTION
Added a new flag `-L` to use ytfzf as search tool, the youtube URL of the selected link will be printed out to stdout. I didn't go through all of the code so I may have missed something.

Edit: This doesn't work together with downloading thumbnails.