### PR TITLE
added error message when stdin is used and -  is not provided

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -84,7 +84,10 @@ format_fzf () {
 	date_len=14
 	url_len=12
 
-	t_size="$(stty size | cut -f2 -d' ')"
+	t_size="$(stty size 2> /dev/null | cut -f2 -d' ')"
+	if [ "$t_size" = "" ]; then
+	    printf "\e[31mWhen using stdin put - for the search query\033[000m\n" && exit 2
+	fi
 	if [ $t_size -lt 75 ]; then
 		# title channel
 		frac=$(((t_size - 1)/4))


### PR DESCRIPTION
stty errors go to /dev/null and if it fails gives an error message about stdin because stty seems to only fail when stdin is given and - is not given for a search query