### PR TITLE
Exit earlier if dependency missing

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -30,29 +30,39 @@ thumb_dir="$YTFZF_CACHE"/thumb
 [ -d $thumb_dir ] || mkdir -p $thumb_dir
 
 
+# DEP CHECK
+dep_ck () {
+	for dep in "$@"; do
+		command -v "$dep" 1>/dev/null || { printf "$dep not found. Please install it.\n" ; exit 2; }
+	done
+}
+dep_ck "jq" "youtube-dl" "$YTFZF_PLAYER";
+
+
 ############################
 #       Help Texts         #
 ############################
 helpinfo () {
-printf "Usage: %bytfzf %b<search query>%b\n" "\033[1;32m" "\033[1;33m" "\033[0m";
+printf "Usage: %bytfzf [OPTIONS] %b<search-query>%b\n" "\033[1;32m" "\033[1;33m" "\033[0m";
+printf "  OPTIONS:\n"
 printf "     -h                    Show this help text\n";
 printf "     -t                    Show thumbnails (requires ueberzug)\n";
 printf "                           Doesn't work with -H -D\n";
 printf "     -D                    Use external menu(default dmenu) instead of fzf \n";
 printf "     -H                    Choose from history \n";
 printf "     -x                    Delete history\n";
-printf "     -m  <search query>    Audio only (for music)\n";
-printf "     -d  <search query>    Download to current directory\n";
-printf "     -f  <search query>    Show available formats before proceeding\n";
-printf "     -a  <search query>    Auto play the first result, no selector\n";
-printf "     -r  <search query>    Auto play a random result, no selector\n";
-printf "     -n  <link count>       To specify number of videos to select with -a or -r\n";
-printf "     -l  <search query>    Loop: prompt selector again after video ends\n";
-printf "     -s  <search query>    After the video ends make another search \n";
-printf "     -L  <search query>    Prints the selected URL only, helpful for scripting\n";
-printf "  Use - instead of <query> for stdin\n";
+printf "     -m  <search-query>    Audio only (for music)\n";
+printf "     -d  <search-query>    Download to current directory\n";
+printf "     -f  <search-query>    Show available formats before proceeding\n";
+printf "     -a  <search-query>    Auto play the first result, no selector\n";
+printf "     -r  <search-query>    Auto play a random result, no selector\n";
+printf "     -n  <link-count>       To specify number of videos to select with -a or -r\n";
+printf "     -l  <search-query>    Loop: prompt selector again after video ends\n";
+printf "     -s  <search-query>    After the video ends make another search \n";
+printf "     -L  <search-query>    Prints the selected URL only, helpful for scripting\n";
+printf "  Use - instead of <search-query> for stdin\n";
 printf "\n"
-printf "  Option can be combines. Like\n"
+printf "  Option can be combined. Like\n"
 printf "     ytfzf -fDH            to show history using external \n"
 printf "                           menu and show formats\n"
 printf "\n"
@@ -390,14 +400,6 @@ get_history () {
 	fi
 }
 
-
-# DEP CHECK
-dep_ck () {
-	for dep in "$@"; do
-		command -v "$dep" 1>/dev/null || { printf "$dep not found. Please install it.\n" ; exit 2; }
-	done
-}
-dep_ck "jq" "youtube-dl" "mpv";
 
 # Opt variables
 is_ext_menu=0


### PR DESCRIPTION
If there's a dependency missing, I don't think there's any reason to create functions and do a bunch of operations before reporting it with a crash. The CPU time and the memory footprint are minor, but it's just good practice if the crash happens before all the functions and other things are defined. Also, I think putting a `[OPTIONS]` indicator in the help screen would be nice. Many programs have it (for example, kitty, python, gcc) and it makes things clearer (where to put the flags, where to put args). Explicit is better than implicit, after all.

It's also conventional to use hyphens or underscores instead of spaces in indicators like `search-query`.

These are just suggestions. Please feel free to edit as you see fit, or close the PR if inappropriate.