### PR TITLE
Revert change to dep_ck function

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -36,7 +36,7 @@ dep_ck () {
 		command -v "$dep" 1>/dev/null || { printf "$dep not found. Please install it.\n" ; exit 2; }
 	done
 }
-dep_ck "jq" "youtube-dl" "$YTFZF_PLAYER";
+dep_ck "jq" "youtube-dl" "mpv";
 
 
 ############################


### PR DESCRIPTION
Reverting a change I made in [PR#58](https://github.com/pystardust/ytfzf/pull/58) which incorrectly causes crashes when `YTFZF_PLAYER` has multiple words.

It'd still be nice to have a better `dep_ck` function so that mpv wouldn't be a hard dependency. It isn't, really, and one could probably use VLC or some other player to the same effect.