### PR TITLE
Option parsing refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,22 @@ Initially this used to be a single line script. But for portability and extensib
 
 ```
 Usage: ytfzf <search query>
-     -h                    Show this help text
-     -t                    Show thumbnails (requires ueberzug)
-                           Doesn't work with -H -D
-     -D                    Use external menu(default dmenu) instead of fzf
-     -H                    Choose from history
-     -x                    Delete history
-     -m  <search query>    Audio only (for music)
-     -d  <search query>    Download to current directory
-     -f  <search query>    Show available formats before proceeding
-     -a  <search query>    Auto play the first result, no selector
-     -r  <search query>    Auto play a random result, no selector
-	 -n  <link count>       To specify number of videos to select with -a or -r
-     -l  <search query>    Loop: prompt selector again after video ends
-     -s  <search query>    After the video ends make another search
-     -L  <search query>    Prints the selected URL only, helpful for scripting
-  Use - instead of <query> for stdin
+     -h, --help                           Show this help text
+     -t, --thumbnails                     Show thumbnails (requires ueberzug)
+                                          Doesn't work with -H -D
+     -D, --ext-menu                       Use external menu(default dmenu) instead of fzf 
+     -H, --choose-from-history            Choose from history 
+     -x, --clear-history                  Delete history
+     -m, --audio-only   <search-query>    Audio only (for music)
+     -d, --download     <search-query>    Download to current directory
+     -f                 <search-query>    Show available formats before proceeding
+     -a, --auto-play    <search-query>    Auto play the first result, no selector
+     -r  --random-play  <search-query>    Auto play a random result, no selector
+     -n, --link-count=  <link-count>      To specify number of videos to select with -a or -r
+     -l, --loop         <search-query>    Loop: prompt selector again after video ends
+     -s                 <search-query>    After the video ends make another search 
+     -L, --link-only    <search-query>    Prints the selected URL only, helpful for scripting
+  Use - instead of <search-query> for stdin
 ```
 
 * To use dmenu with a custom width

--- a/ytfzf
+++ b/ytfzf
@@ -56,7 +56,7 @@ printf "     -d, --download     <search-query>    Download to current directory\
 printf "     -f  	        <search-query>    Show available formats before proceeding\n";
 printf "     -a, --auto-play    <search-query>    Auto play the first result, no selector\n";
 printf "     -r  --random-play  <search-query>    Auto play a random result, no selector\n";
-printf "     -n, --link-count   <link-count>      To specify number of videos to select with -a or -r\n";
+printf "     -n, --link-count=   <link-count>      To specify number of videos to select with -a or -r\n";
 printf "     -l, --loop	        <search-query>    Loop: prompt selector again after video ends\n";
 printf "     -s  	        <search-query>    After the video ends make another search \n";
 printf "     -L, --link-only    <search-query>    Prints the selected URL only, helpful for scripting\n";

--- a/ytfzf
+++ b/ytfzf
@@ -417,8 +417,8 @@ link_count=1
 parse_opt () {
 	#the first arg is the option
 	opt=$1
-	#second arg is the optarg defaults to empty
-	OPTARG="${2-}"
+	#second arg is the optarg 
+	OPTARG="$2"
 	case ${opt} in
 		#Long options
 		-)
@@ -452,52 +452,52 @@ parse_opt () {
 
 				random-auto-play) parse_opt "r" ;;
 
-				*) parse_opt "UNKNOWN" ;;
+				*)
+				    printf "Illegal option --$OPTARG\n"
+				    usageinfo
+				    exit 2;
+				    ;;
 			esac
 			;;
 		#Short options
 		h) 	helpinfo
-			exit;
-			;;
-		D) 	is_ext_menu="1"
-			;;
-		m) 	YTFZF_PREF="bestaudio"
-			;;
+			exit ;;
+
+		D) 	is_ext_menu="1" ;;
+
+		m) 	YTFZF_PREF="bestaudio" ;;
+
 		d) 	YTFZF_PLAYER="youtube-dl"
-		   	YTFZF_PLAYER_FORMAT="youtube-dl -f "
-			;;
-		f) 	show_format=1
-			;;
-		H)	get_history
-			;;
+			YTFZF_PLAYER_FORMAT="youtube-dl -f " ;;
+		f) 	show_format=1 ;;
+
+		H)	get_history ;;
+
 		x)	[ -e "$history_file" ] && rm "$history_file" && touch "$history_file" && printf "History has been cleared\n"
-			exit;
-			;;
-		a) 	auto_select=1
-			;;
-		r)
-			random_select=1
-			;;
+			exit ;;
+		a) 	auto_select=1 ;;
+
+		r)	random_select=1 ;;
+
 		s)	search_again=1
-		 	YTFZF_LOOP=1
-			;;
-		l) 	YTFZF_LOOP=1
-			;;
-		t) 	show_thumbnails=1
-			;;
-		L) 	show_link_only=1
-			;;
-		n)	link_count="$OPTARG"	
-			;;
+		 	YTFZF_LOOP=1 ;;
+
+		l) 	YTFZF_LOOP=1 ;;
+
+		t) 	show_thumbnails=1 ;;
+
+		L) 	show_link_only=1 ;;
+
+		n)	link_count="$OPTARG" ;;
+
 		U) 	[ -p "$FIFO" ] && preview_img "$OPTARG"; exit;
+
 			# This option is reserved for the script, to show image previews
 			# Not to be used by explicitly
 			;;
 		*)
-			printf "${OPT-Option} not found!\n"
 			usageinfo
-			exit 2;
-			;;
+			exit 2 ;;
 	esac
 }
 

--- a/ytfzf
+++ b/ytfzf
@@ -45,21 +45,21 @@ dep_ck "jq" "youtube-dl" "$YTFZF_PLAYER";
 helpinfo () {
 printf "Usage: %bytfzf [OPTIONS] %b<search-query>%b\n" "\033[1;32m" "\033[1;33m" "\033[0m";
 printf "  OPTIONS:\n"
-printf "     -h, --help            		Show this help text\n";
-printf "     -t, --thumbnails      		Show thumbnails (requires ueberzug)\n";
-printf "                           		Doesn't work with -H -D\n";
-printf "     -D, --ext-menu        		Use external menu(default dmenu) instead of fzf \n";
-printf "     -H, --choose-from-history   	Choose from history \n";
-printf "     -x, --clear-history       		Delete history\n";
-printf "     -m, --audio-only <search-query>    Audio only (for music)\n";
-printf "     -d, --download   <search-query>    Download to current directory\n";
-printf "     -f  	      <search-query>    Show available formats before proceeding\n";
-printf "     -a, --auto-play  <search-query>    Auto play the first result, no selector\n";
-printf "     -r               <search-query>    Auto play a random result, no selector\n";
-printf "     -n, --link-count <link-count>      To specify number of videos to select with -a or -r\n";
-printf "     -l, --loop	      <search-query>    Loop: prompt selector again after video ends\n";
-printf "     -s  	      <search-query>    After the video ends make another search \n";
-printf "     -L, --link-only  <search-query>    Prints the selected URL only, helpful for scripting\n";
+printf "     -h, --help            		  Show this help text\n";
+printf "     -t, --thumbnails      		  Show thumbnails (requires ueberzug)\n";
+printf "                           		  Doesn't work with -H -D\n";
+printf "     -D, --ext-menu        		  Use external menu(default dmenu) instead of fzf \n";
+printf "     -H, --choose-from-history   	  Choose from history \n";
+printf "     -x, --clear-history       		  Delete history\n";
+printf "     -m, --audio-only   <search-query>    Audio only (for music)\n";
+printf "     -d, --download     <search-query>    Download to current directory\n";
+printf "     -f  	        <search-query>    Show available formats before proceeding\n";
+printf "     -a, --auto-play    <search-query>    Auto play the first result, no selector\n";
+printf "     -r  --random-play  <search-query>    Auto play a random result, no selector\n";
+printf "     -n, --link-count   <link-count>      To specify number of videos to select with -a or -r\n";
+printf "     -l, --loop	        <search-query>    Loop: prompt selector again after video ends\n";
+printf "     -s  	        <search-query>    After the video ends make another search \n";
+printf "     -L, --link-only    <search-query>    Prints the selected URL only, helpful for scripting\n";
 printf "  Use - instead of <search-query> for stdin\n";
 printf "\n"
 printf "  Option usage:\n"
@@ -414,63 +414,43 @@ show_format=0
 link_count=1
 
 #OPT
-while getopts "LhDmdfxHarltsn:U:-:" opt; do
+
+parse_opt () {
+	opt=$1
+	OPTARG="${2-}"
 	case ${opt} in
 		#Long options
 		-)
 			case "${OPTARG}" in
-				help)
-				    helpinfo
-				    exit;
-				    ;;
-				ext-menu)
-				    is_ext_menu="1"
-				    ;;
-				download)
-				    YTFZF_PLAYER="youtube-dl"
-				    YTFZF_PLAYER_FORMAT="youtube-dl -f"
-				    ;;
-				choose-from-history)
-				    get_history
-				    ;;
-				clear-history)
-				    [ -e "$history_file" ] && rm "$history_file" && touch "$history_file" && printf "History has been cleared\n"
-				    exit
-				    ;;
-				auto-select)
-				    auto_select=1
-				    ;;
-				random-select)
-				    random_select=1
-				    ;;
-				search)
-				    search_again=1
-				    YTFZF_LOOP=1
-				    ;;
-				loop)
-				    YTFZF_LOOP=1
-				    ;;
-				show-thumbnails|thumbnails)
-				    show_thumbnails=1
-				    ;;
-				link|link-only)
-				    show_link_only=1
-				    ;;
-				link-count=*)
-				    link_count=${OPTARG#*=}
-				    ;;
-				audio-only)
-				    YTFZF_PREF="bestaudio"
-				    ;;
-				auto-play)
-				    auto_select=1
-				    ;;
-				*)
-				    printf "--$OPTARG not found\n"
-				    usageinfo
-				    exit 2;
-				    ;;
+			        help) parse_opt "h" ;;
 
+				ext-menu) parse_opt "D" ;;
+
+				download) parse_opt "d" ;;
+
+				choose-from-history) parse_opt "H" ;;
+
+				clear-history) parse_opt "x" ;;
+
+				random-select) parase_opt "r" ;;
+
+				search) parse_opt "s" ;;
+
+				loop) parse_opt "l" ;;
+
+				thumbnails) parse_opt "t" ;;
+
+				link-only) parse_opt "L" ;;
+
+				link-count=*) parse_opt "n" "${OPTARG#*=}" ;;
+
+				audio-only) parse_opt "m" ;;
+
+				auto-play) parse_opt "a" ;;
+
+				random-auto-play) parse_opt "r" ;;
+
+				*) parse_opt "UNKNOWN" ;;
 			esac
 			;;
 		#Short options
@@ -517,6 +497,10 @@ while getopts "LhDmdfxHarltsn:U:-:" opt; do
 			exit 2;
 			;;
 	esac
+}
+
+while getopts "LhDmdfxHarltsn:U:-:" opt; do
+    parse_opt "$opt" "$OPTARG"
 done
 shift $((OPTIND-1))
 

--- a/ytfzf
+++ b/ytfzf
@@ -45,20 +45,20 @@ dep_ck "jq" "youtube-dl" "$YTFZF_PLAYER";
 helpinfo () {
 printf "Usage: %bytfzf [OPTIONS] %b<search-query>%b\n" "\033[1;32m" "\033[1;33m" "\033[0m";
 printf "  OPTIONS:\n"
-printf "     -h, --help            		  Show this help text\n";
-printf "     -t, --thumbnails      		  Show thumbnails (requires ueberzug)\n";
-printf "                           		  Doesn't work with -H -D\n";
-printf "     -D, --ext-menu        		  Use external menu(default dmenu) instead of fzf \n";
-printf "     -H, --choose-from-history   	  Choose from history \n";
-printf "     -x, --clear-history       		  Delete history\n";
+printf "     -h, --help                           Show this help text\n";
+printf "     -t, --thumbnails                     Show thumbnails (requires ueberzug)\n";
+printf "                                          Doesn't work with -H -D\n";
+printf "     -D, --ext-menu                       Use external menu(default dmenu) instead of fzf \n";
+printf "     -H, --choose-from-history            Choose from history \n";
+printf "     -x, --clear-history                  Delete history\n";
 printf "     -m, --audio-only   <search-query>    Audio only (for music)\n";
 printf "     -d, --download     <search-query>    Download to current directory\n";
-printf "     -f  	        <search-query>    Show available formats before proceeding\n";
+printf "     -f                 <search-query>    Show available formats before proceeding\n";
 printf "     -a, --auto-play    <search-query>    Auto play the first result, no selector\n";
 printf "     -r  --random-play  <search-query>    Auto play a random result, no selector\n";
-printf "     -n, --link-count=  <link-count>      To specify number of videos to select with -a or -r\n";
-printf "     -l, --loop	        <search-query>    Loop: prompt selector again after video ends\n";
-printf "     -s  	        <search-query>    After the video ends make another search \n";
+printf "     -n, --link-count=  <link-count>	  To specify number of videos to select with -a or -r\n";
+printf "     -l, --loop         <search-query>    Loop: prompt selector again after video ends\n";
+printf "     -s                 <search-query>    After the video ends make another search \n";
 printf "     -L, --link-only    <search-query>    Prints the selected URL only, helpful for scripting\n";
 printf "  Use - instead of <search-query> for stdin\n";
 printf "\n"

--- a/ytfzf
+++ b/ytfzf
@@ -45,26 +45,27 @@ dep_ck "jq" "youtube-dl" "$YTFZF_PLAYER";
 helpinfo () {
 printf "Usage: %bytfzf [OPTIONS] %b<search-query>%b\n" "\033[1;32m" "\033[1;33m" "\033[0m";
 printf "  OPTIONS:\n"
-printf "     -h                    Show this help text\n";
-printf "     -t                    Show thumbnails (requires ueberzug)\n";
-printf "                           Doesn't work with -H -D\n";
-printf "     -D                    Use external menu(default dmenu) instead of fzf \n";
-printf "     -H                    Choose from history \n";
-printf "     -x                    Delete history\n";
-printf "     -m  <search-query>    Audio only (for music)\n";
-printf "     -d  <search-query>    Download to current directory\n";
-printf "     -f  <search-query>    Show available formats before proceeding\n";
-printf "     -a  <search-query>    Auto play the first result, no selector\n";
-printf "     -r  <search-query>    Auto play a random result, no selector\n";
-printf "     -n  <link-count>       To specify number of videos to select with -a or -r\n";
-printf "     -l  <search-query>    Loop: prompt selector again after video ends\n";
-printf "     -s  <search-query>    After the video ends make another search \n";
-printf "     -L  <search-query>    Prints the selected URL only, helpful for scripting\n";
+printf "     -h, --help            		Show this help text\n";
+printf "     -t, --thumbnails      		Show thumbnails (requires ueberzug)\n";
+printf "                           		Doesn't work with -H -D\n";
+printf "     -D, --ext-menu        		Use external menu(default dmenu) instead of fzf \n";
+printf "     -H, --choose-from-history   	Choose from history \n";
+printf "     -x, --clear-history       		Delete history\n";
+printf "     -m, --audio-only <search-query>    Audio only (for music)\n";
+printf "     -d, --download   <search-query>    Download to current directory\n";
+printf "     -f  	      <search-query>    Show available formats before proceeding\n";
+printf "     -a, --auto-play  <search-query>    Auto play the first result, no selector\n";
+printf "     -r               <search-query>    Auto play a random result, no selector\n";
+printf "     -n, --link-count <link-count>      To specify number of videos to select with -a or -r\n";
+printf "     -l, --loop	      <search-query>    Loop: prompt selector again after video ends\n";
+printf "     -s  	      <search-query>    After the video ends make another search \n";
+printf "     -L, --link-only  <search-query>    Prints the selected URL only, helpful for scripting\n";
 printf "  Use - instead of <search-query> for stdin\n";
 printf "\n"
-printf "  Option can be combined. Like\n"
-printf "     ytfzf -fDH            to show history using external \n"
-printf "                           menu and show formats\n"
+printf "  Option usage:\n"
+printf "     ytfzf -fDH            		to show history using external \n"
+printf "                           		menu and show formats\n"
+printf "     ytfzf -fD --choose-from-history	same as above\n"
 printf "\n"
 printf "  Defaults can be modified through ENV variables\n";
 printf "  Defaults:\n";
@@ -411,9 +412,68 @@ random_select=0
 search_again=0
 show_format=0
 link_count=1
-# OPT
-while getopts "LhDmdfxHarltsn:U:" opt; do
+
+#OPT
+while getopts "LhDmdfxHarltsn:U:-:" opt; do
 	case ${opt} in
+		#Long options
+		-)
+			case "${OPTARG}" in
+				help)
+				    helpinfo
+				    exit;
+				    ;;
+				ext-menu)
+				    is_ext_menu="1"
+				    ;;
+				download)
+				    YTFZF_PLAYER="youtube-dl"
+				    YTFZF_PLAYER_FORMAT="youtube-dl -f"
+				    ;;
+				choose-from-history)
+				    get_history
+				    ;;
+				clear-history)
+				    [ -e "$history_file" ] && rm "$history_file" && touch "$history_file" && printf "History has been cleared\n"
+				    exit
+				    ;;
+				auto-select)
+				    auto_select=1
+				    ;;
+				random-select)
+				    random_select=1
+				    ;;
+				search)
+				    search_again=1
+				    YTFZF_LOOP=1
+				    ;;
+				loop)
+				    YTFZF_LOOP=1
+				    ;;
+				show-thumbnails|thumbnails)
+				    show_thumbnails=1
+				    ;;
+				link|link-only)
+				    show_link_only=1
+				    ;;
+				link-count=*)
+				    link_count=${OPTARG#*=}
+				    ;;
+				audio-only)
+				    YTFZF_PREF="bestaudio"
+				    ;;
+				auto-play)
+				    auto_select=1
+				    ;;
+				*)
+				    printf "--$OPTARG not found\n"
+				    usageinfo
+				    exit 2;
+				    ;;
+
+			esac
+			;;
+		#Short options
 		h) 	helpinfo
 			exit;
 			;;
@@ -452,13 +512,14 @@ while getopts "LhDmdfxHarltsn:U:" opt; do
 			# Not to be used by explicitly
 			;;
 		*)
-			printf "Option not found!\n"
+			printf "${OPT-Option} not found!\n"
 			usageinfo
 			exit 2;
 			;;
 	esac
 done
 shift $((OPTIND-1))
+
 [ "$*" = "-" ] && is_stdin=1 || is_stdin=0
 search_query="$*"
 check_if_url "$search_query" 

--- a/ytfzf
+++ b/ytfzf
@@ -473,7 +473,7 @@ parse_opt () {
 
 		H)	get_history ;;
 
-		x)	[ -e "$history_file" ] && rm "$history_file" && touch "$history_file" && printf "History has been cleared\n"
+		x)	[ -e "$history_file" ] && (echo "" > "$history_file") && printf "History has been cleared\n"
 			exit ;;
 
 		a) 	auto_select=1 ;;

--- a/ytfzf
+++ b/ytfzf
@@ -457,8 +457,7 @@ parse_opt () {
 				    usageinfo
 				    exit 2;
 				    ;;
-			esac
-			;;
+			esac ;;
 		#Short options
 		h) 	helpinfo
 			exit ;;
@@ -469,12 +468,14 @@ parse_opt () {
 
 		d) 	YTFZF_PLAYER="youtube-dl"
 			YTFZF_PLAYER_FORMAT="youtube-dl -f " ;;
+
 		f) 	show_format=1 ;;
 
 		H)	get_history ;;
 
 		x)	[ -e "$history_file" ] && rm "$history_file" && touch "$history_file" && printf "History has been cleared\n"
 			exit ;;
+
 		a) 	auto_select=1 ;;
 
 		r)	random_select=1 ;;
@@ -491,10 +492,10 @@ parse_opt () {
 		n)	link_count="$OPTARG" ;;
 
 		U) 	[ -p "$FIFO" ] && preview_img "$OPTARG"; exit;
-
 			# This option is reserved for the script, to show image previews
 			# Not to be used by explicitly
 			;;
+
 		*)
 			usageinfo
 			exit 2 ;;

--- a/ytfzf
+++ b/ytfzf
@@ -56,7 +56,7 @@ printf "     -d, --download     <search-query>    Download to current directory\
 printf "     -f  	        <search-query>    Show available formats before proceeding\n";
 printf "     -a, --auto-play    <search-query>    Auto play the first result, no selector\n";
 printf "     -r  --random-play  <search-query>    Auto play a random result, no selector\n";
-printf "     -n, --link-count=   <link-count>      To specify number of videos to select with -a or -r\n";
+printf "     -n, --link-count=  <link-count>      To specify number of videos to select with -a or -r\n";
 printf "     -l, --loop	        <search-query>    Loop: prompt selector again after video ends\n";
 printf "     -s  	        <search-query>    After the video ends make another search \n";
 printf "     -L, --link-only    <search-query>    Prints the selected URL only, helpful for scripting\n";
@@ -414,13 +414,15 @@ show_format=0
 link_count=1
 
 #OPT
-
 parse_opt () {
+	#the first arg is the option
 	opt=$1
+	#second arg is the optarg defaults to empty
 	OPTARG="${2-}"
 	case ${opt} in
 		#Long options
 		-)
+			#if the option has a short version it calls this function with the opt as the shortopt
 			case "${OPTARG}" in
 			        help) parse_opt "h" ;;
 


### PR DESCRIPTION
This doesn't necessarily need to be merged but, I feel making a way for longopts to be used would be good and this was the easiest way to implement that (that i found)

I tried just parsing the options manually but it resulted in some funky behavior with the regular search query input so i scrapped it. It might be possible to do it, I just don't know how

Printf "Option not found" is removed because getopts already does that, but since getopts doesn't have default support for long opts, I added an error message similar to getopts' when an invalid longopt is used