### PR TITLE
change install location to /usr/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ PREFIX = /usr/bin
 
 install:
 	chmod 755 $(PROG)
+	mkdir -p ${DESTDIR}${PREFIX}
 	install ${PROG} ${DESTDIR}${PREFIX}/${PROG}
 
 uninstall:
-	rm -f ${DESTDIR}${PREFIX}/bin/${PROG}
+	rm -f ${DESTDIR}${PREFIX}/${PROG}
 
 .PHONY: install uninstall

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 PROG=ytfzf
 
-PREFIX = /usr/local
+PREFIX = /usr/bin
 
 install:
 	chmod 755 $(PROG)
-	install ${PROG} ${DESTDIR}${PREFIX}/bin/${PROG}
+	install ${PROG} ${DESTDIR}${PREFIX}/${PROG}
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/${PROG}


### PR DESCRIPTION
According to Arch Package Guidlines: https://wiki.archlinux.org/index.php/Arch_package_guidelines#Package_etiquette

> Packages should never be installed to /usr/local/

I would like to use makefile in AUR's PKGBUILD