### PR TITLE
change install loc, depending on OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 PROG=ytfzf
 
-PREFIX = /usr/bin
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+    PREFIX = /usr/local/bin
+endif
+ifeq ($(UNAME), Linux)
+    PREFIX = /usr/bin
+endif
 
 install:
 	chmod 755 $(PROG)


### PR DESCRIPTION
>Hey guys, Im running into some problems with installing ytfzf:
```
chmod 755 ytfzf
mkdir -p /usr/bin
install ytfzf /usr/bin/ytfzf
install: /usr/bin/ytfzf: Read-only file system
make: *** [install] Error 71
```
 > Is someone able to help me out on this one?

Apparently on mac, the install location needs to be /usr/local/bin
