### PR TITLE
enable `thumb_dir` to be relocated via `conf.sh`

### DIFF
--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -171,6 +171,9 @@ history_file="$YTFZF_CACHE/ytfzf_hst"
 #the file for writing the menu option that was chosen
 current_file="$YTFZF_CACHE/ytfzf_cur"
 
+#the folder where thumbnails are cached
+thumb_dir="$YTFZF_CACHE/thumb"
+
 #when displaying thumbnails, use the text printed in this function to show the title, views, etc..
 thumbnail_video_info_text () {
          printf "\n${c_cyan}%s" "$title"

--- a/ytfzf
+++ b/ytfzf
@@ -54,13 +54,12 @@ printf "" > "$tmp_video_data_file"
 #> files and directories
 history_file="${history_file-$YTFZF_CACHE/ytfzf_hst}"
 current_file="${current_file-$YTFZF_CACHE/ytfzf_cur}"
-thumb_dir="$YTFZF_CACHE/thumb"
+thumb_dir="${thumb_dir-$YTFZF_CACHE/thumb}"
 #> Stores urls of the video page of channels
 subscriptions_file="${subscriptions_file-$config_dir/subscriptions}"
 
 #> stores the pid of running ytfzf sessions
 pid_file="$YTFZF_CACHE/.pid"
-thumb_dir="$YTFZF_CACHE/thumb"
 #> make folders that don't exist
 [ -d "$YTFZF_CACHE" ] || mkdir -p "$YTFZF_CACHE"
 [ -d "$thumb_dir" ] || mkdir -p "$thumb_dir"


### PR DESCRIPTION
This might be desirable for example if a user wants to use a folder on a
tmpfs filesystem to cache thumbnails.

Thx a lot for sharing your awesome script by the way ! :+1: