### PR TITLE
fix preview text on alien locales

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -322,7 +322,7 @@ stop_ueberzug () {
     rm "$FIFO" > /dev/null 2>&1
 }
 
-if  [ -z "$(type thumbnail_video_info_text | grep 'function')" ] ; then
+if  [ -z "$(LANG=C type thumbnail_video_info_text | grep 'function')" ] ; then
     thumbnail_video_info_text () {
 	printf "\n${c_cyan}%s" "$title"
 	printf "\n${c_blue}Channel	${c_green}%s" "$channel"


### PR DESCRIPTION
The output of `type` is localized.  For example, `function` in German is
`Funktion`,  which makes the `grep` statement return false when it actu-
ally should return true.
`LANG=C` unifies this.
