### PR TITLE
Development merge 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,61 +24,157 @@
 
 _These links will take you where you want to go with the snap of a finger_
 
-- [`Usage instruction`](#Usage-Instructions)
 - [`Features`](#Features)
+- [`Usage instruction`](#Usage-Instructions)
 - [`Examples`](#Examples)
 - [`Dependencies`](#Dependencies)
 - [`Installation`](#Installation)
-- [`Configuration`](#Configuration)
-- [`External menu command (dmenu / rofi)`](#External-menu-command)
-
-_Initially this used to be a single line script._
-
-```sh
-#!/bin/sh
-[ -z "$*" ] || curl "https://www.youtube.com/results" -s -G --data-urlencode "search_query=$*" |  pup 'script' | grep  "^ *var ytInitialData" | sed 's/^[^=]*=//g;s/;$//' | jq '..|.videoRenderer?' | sed '/^null$/d' | jq '.title.runs[0].text,.longBylineText.runs[0].text,.shortViewCountText.simpleText,.lengthText.simpleText,.publishedTimeText.simpleText,.videoId'| sed 's/^"//;s/"$//;s/\\"//g' | sed -E -n "s/(.{60}).*/\1/;N;s/\n(.{30}).*/\n\1/;N;N;N;N;s/\n/\t|/g;p" | column -t  -s "$(printf "\t")" | fzf --delimiter='\|' --nth=1,2  | sed -E 's_.*\|([^|]*)$_https://www.youtube.com/watch?v=\1_' | xargs -r -I'{}' mpv {}
-```
-
-## Usage-Instructions
-
-```
-Basic Usage: ytfzf [OPTIONS] <search-query>
-  OPTIONS:
-     -h, --help                           Show this help text
-     -t, --thumbnails                     Show thumbnails (requires ueberzug)
-                                          Doesn't work with -H -D
-     -D, --ext-menu                       Use external menu(default dmenu) instead of fzf
-     -H, --choose-from-history            Choose from history
-     -x, --clear-history                  Delete history
-     -m, --audio-only   <search-query>    Audio only (for music)
-     -d, --download     <search-query>    Download to current directory
-     -f                 <search-query>    Show available formats before proceeding
-     -a, --auto-play    <search-query>    Auto play the first result, no selector
-     -r  --random-play  <search-query>    Auto play a random result, no selector
-     -n, --video-count= <video-count>     To specify number of videos to select with -a or -r
-     -l, --loop         <search-query>    Loop: prompt selector again after video ends
-     -s                 <search-query>    After the video ends make another search
-     -L, --link-only    <search-query>    Prints the selected URL only, helpful for scripting
-  Use - instead of <search-query> for stdin
-```
-> To quit the script you can press `ESC` or `^C` in the video selection prompt.
-
-_**To use dmenu with a custom width**_
-
-```sh
-YTFZF_EXTMENU_LEN=250 ytfzf -D
-```
-
-_Videos can be selected using fzf, dmenu or rofi._
 
 ## Features
 
 * Thumbnails
-* History support
-* Download support
-* Format selection (and default formats)
-* Queue multiple tracks (using fzf multiselection)
+* History
+* Download
+* Format selection
+* Queue multiple videos
 
+## Usage-Instructions
+
+```sh
+ytfzf [Options] <search-query>
+```
+
+_Videos can be selected using fzf, dmenu or rofi._
+
+> To quit the script you can press `ESC` or `^C` in the video selection prompt.
+
++ **Config file**: `~/.config/ytfzf/conf.sh`, [`example config file`](docs/conf.sh). 
+
+***Any variable change mentioned below can be exported, or added to the config file.***
+
++ **Thumbnails**: requires ueberzug (works only on X11), _doesn't work on wayland and macos_
+
+	ytfzf -t <search-query>
+
+
+> Thumbnails preview side could be changed to the right with `--preview-side=right`
+
++ **History**: 
+
+	ytfzf -H
+
+	+ clear history
+
+	ytfzf -x
+
+	+ History file: `~/.cache/ytfzf/ytfzf_hst`
+
+> History is enabled by default. To turn it off you can export `YTFZF_HIST=0` or set add it to the config file.
+
++ **External menu**
+
+	+ `-D`: To use external menu
+
+	+ By default the external menu is set to `dmenu -i -l 30`. This can be changed to `rofi`
+
+	```sh
+	YTFZF_EXTMENU=' rofi -dmenu -fuzzy -width 1500'
+	```
+
+	+ The width of external menu can be adjusted with `YTFZF_EXTMENU_LEN=220`.
+
++ **Format-selction and download**
+
+	+ Video format can be set as per [youtube-dl formatting](https://github.com/ytdl-org/youtube-dl#format-selection).
+
+	```sh
+	YTFZF_PREF="22"                   # 22 for 720p
+	```
+
+	+ `-f`: To view and select available formats.
+	+ `-m`: (audio-only) Only audio format (best audio)
+
+	+ `-d`: (download) To **download** a video instead of playing it.
+
++ **Multi-selection**: multiple videos can be queued up using `fzf`'s auto multi-selection (tab). To traverse between selected videos use `<` and `>`.
+
++ **Looping, Searches**
+
+	+ `-l`: (loop) would prompt the video menu every time a video finishes. Press `ESC` or `^C` to exit loop.
+	+ `-s`: (search-again) would ask for another search query as the video ends.
+
++ **Auto and random selection**
+To select videos *without video prompt*, if multiple videos are selected then they would play one after the other. The variable **n** represents the link count. Which is 1 by default.
+
+	+ `-A`: (select-all) selects all the videos.
+	+ `-a`: (auto-selection) selects the first **n**(=1) result.
+	+ `-r`: (auto-selection) Randomly selects **n**(=1) results (shuffles them).
+
+	+ `-n <number>` : (link-count) Set **n** the number of links to be selected.
+
++ **Subscriptions**
+
+Subscriptions are managed in subscription file: `~/.config/ytfzf/subscriptions`.
+
+	+ Adding a certain channel to subscriptions
+	
+	1. Open the channel page on a browser and go to the vidoes tab (located right below the channel name and subscription count).
+	2. Copy the url of videos page. And add it to your subscription file.
+	3. The url for each subscription must be on a separate line.
+	
+_The subscription file needs to have only the channels' video page url. Comments can be added with `#`_
+
+	```
+	# file : ~/.config/ytfzf/subscriptions
+	## tech channels
+	https://www.youtube.com/c/LukeSmithxyz/videos                   #luke smith
+	https://www.youtube.com/channel/UCngn7SVujlvskHRvRKc1cTw/videos #bugswriter
+	https://www.youtube.com/c/DistroTube/videos                     #distrotube
+	https://www.youtube.com/c/MentalOutlaw/videos                   #mental outlaw
+	```
+	
+	+ To see subscriptions' latest videos
+	
+	```sh
+	# Defaults to 10 results from each channel
+	ytfzf -S
+
+	# To show 15 results instead
+	ytfzf --subs=15
+	```
+	
+_This can be combined with other options like thumbnails_
+	```sh
+	ytfzf -tS
+	```
+
++ **Custom Player**
+By default, `ytfzf` uses `mpv`. Custom player should have the ability to launch youtube links (example: `vlc`).
+
+	```sh
+	# example: using devour
+	FZF_PLAYER="devour mpv"
+	YTFZF_PLAYER_FORMAT="devour mpv --ytdl-format="
+	```
+
+
++ **Misc**
+
+	+ The currently playing video details are stored in `~/.cache/ytfzf_cur` (for status bar modules)
+
+	+ Files and directories used by ytfzf can be set in the config file
+	```sh
+	cache_dir="$HOME/.cache/ytfzf"
+	history_file="$YTFZF_CACHE/ytfzf_hst"
+	current_file="$YTFZF_CACHE/ytfzf_cur"
+	thumb_dir="$YTFZF_CACHE/thumb"
+	```
+
+### Useful mpv key bindings
+
+- `f`    :  full screen
+- `j`,`J`:  cycle subtitles (also works with audio, if the music video has subtitles)
+- `L`    :  single-loop
 
 ## Examples
 
@@ -88,11 +184,9 @@ _Videos can be selected using fzf, dmenu or rofi._
 
        ytfzf -t <query>
 
-+  Search without Thumbnails
+	> Show all subscriptions with thumbnails (latest 10)
 
-	> Find and watch videos without thumbnail previews (good if are on MacOS for example)
-
-	   ytfzf <query>
+       ytfzf -St
 
 +  You can use multiple options together, here are some examples
 
@@ -104,7 +198,7 @@ _Videos can be selected using fzf, dmenu or rofi._
 
 	      ytfzf -dH
 
-	- Open using dmenu in a certain format
+	- Open using external menu in a certain format
 
 	 	  ytfzf -fD
 
@@ -114,11 +208,6 @@ first hit Q to save position and quit mpv, then choose your format using_
 	  ytfzf -faH
 
 
-### Useful mpv key bindings
-
-* Use `f` for full screen
-* Use `J` for subtitles (also works with audio, if the music video has subtitles)
-* Use `L` for single-loop
 
 ### Update log
 
@@ -169,7 +258,14 @@ _Fzf is optional, you can use an external menu (like dmenu) with the `-D` option
 
 ## Installation
 
-+ #### Cloning the repository
++ #### Installation by direct download
+
+	```sh
+	sudo curl -L "https://raw.githubusercontent.com/pystardust/ytfzf/master/ytfzf" -o /usr/bin/ytfzf
+	sudo chmod +x /usr/bin/ytfzf
+	```
+
++ #### Installation by cloning the repository
 
 	```sh
 	git clone https://github.com/pystardust/ytfzf
@@ -197,153 +293,15 @@ _Fzf is optional, you can use an external menu (like dmenu) with the `-D` option
 		eselect repository enable nitratesky
 		emerge -a1 net-misc/ytfzf
 
-## Configuration
-
-_Default configuration can be set in the configuration file `~/.config/ytfzf/conf.sh` or with environment variables._
-
-+ ##### Defaults can be set in `~/.config/ytfzf/conf.sh`
-	```sh
-	YTFZF_HIST=0 # history is on by default it can be set to -> 0 history off, 1: history on
-	YTFZF_LOOP=1 # if set to 1 it is on but normally it is off by default. Can be turned on using option -l
-	YTFZF_PREF="bestvideo[height<=?1080]+bestaudio/best"
-	YTFZF_ENABLE_FZF_DEFAULT_OPTS=1 # fzf colors are going to be the one from your fzf configuration
-	```
-
-+ ##### Or export them in your shell config
-
-	```sh
-	export YTFZF_HIST=0 # history is on by default it can be set to -> 0 history off, 1: history on
-	export YTFZF_LOOP=1 # if set to 1 it is on but normally it is off by default. Can be turned on using option -l
-	export YTFZF_PREF="bestvideo[height<=?1080]+bestaudio/best"
-	export YTFZF_ENABLE_FZF_DEFAULT_OPTS=1 # fzf colors are going to be the one from your fzf configuration
-	```
-
-+ ##### You can also specify settings that will be only be used for that specific query
-
-	```sh
-	YTFZF_HIST=0 YTFZF_PREF="bestvideo[height<=?1080]+bestaudio/best" ytfzf  <query>
-	```
-	- _The setting in the config will always override environment variables. This command wouldn't function as expected if_ `YTFZF_HIST=1` _was mentioned in the config file._
-
-	- _The example shown above will launch ytfzf without including the video in your history and it will only display the best resolution available at 1080p or lower._
-
-+ ##### This history will be stored in the cache directory as `ytfzf_hst`
-
-	```sh
-	YTFZF_CACHE=~/.cache/ytfzf
-	```
-
-	_You can modify the file location by changing the cache directory_
-
-+ ##### Format
-
-	_If you prefer to watch Youtube videos with certain options without being prompted every single time you can use the following setting_.
-
-	```sh
-	YTFZF_PREF="22"
-	```
-
-	_If the preferred format is not available then it will revert back to auto selection._ [_Documentation for ytdl formats_](https://github.com/ytdl-org/youtube-dl#format-selection)
-
-## Subscriptions
-
-_Subscriptions are managed in subscription file: `~/.config/ytfzf/subscriptions`._
-
-+ #### Adding a certain channel to your subscriptions. 
-
-1. Open the channel page on a browser and go to the vidoes tab (located right below the channel name and subscription count).
-2. Copy the url of videos page. And add it to your subscription file.
-3. The url for each subscription must be on a separate line.
-
-_The subscription file needs to have only the channels' video page url. Comments can be added with `#`_
-```
-# file : ~/.config/ytfzf/subscriptions
-## tech channels
-https://www.youtube.com/c/LukeSmithxyz/videos                   #luke smith
-https://www.youtube.com/channel/UCngn7SVujlvskHRvRKc1cTw/videos #bugswriter
-https://www.youtube.com/c/DistroTube/videos                     #distrotube
-https://www.youtube.com/c/MentalOutlaw/videos                   #mental outlaw
-```
-
-+ #### To see subscriptions latest videos
-
-```sh
-ytfzf -S
-# Defaults to 10 results from each channel
-ytfzf --subs=15
-# To show 15 results instead
-```
-
-_This can be combined with other options like thumbnails_
-```sh
-ytfzf -tS
-```
-
-
-
-## External-menu command
-
-_The currently supported ones are (dmenu / rofi)_
-
-+ ##### To use an external menu you will need to pass in the `-D` option
-	```sh
-	ytfzf -D
-	```
-	_By default the external menu is set to dmenu `dmenu -i -l 30`. You can modify this to use rofi by using the following settings_
-
-	```sh
-	YTFZF_EXTMENU=' rofi -dmenu -fuzzy -width 1500'
-	```
-
-	> I don't use rofi much, I would love to hear from any rofi user on better defaults.
-
-+ ##### You also may need to modify the width of the output that is being piped into the external menu.
-	_Depending on you screen resolution and font size this may need to be modified._
-
-  - **First option**
-
-	```sh
-	YTFZF_EXTMENU_LEN=180
-	```
-
-  - **Second option**
-
-	```sh
-	YTFZF_EXTMENU_LEN=180 ytfzf -D
-	```
-
-> WARNING : dmenu doesn't behave well with some fonts. Expect it to be slow with fonts you don't have.
-
-### Currently Playing
-
-_`YTFZF` is `on` by default. Stores the details of the currently playing track. Empty when nothing is playing. This could be used in status bar modules._
-
-+ ##### This will allow you to disable it
-
-	```sh
-	YTFZF_CUR=0
-	```
-
-	> It will be stored in the ytfzf cache directory as `ytfzf_cur`
-
-### Custom Player
-
-_By default, ytfzf uses `mpv`. Custom player should have the ability to launch youtube links._
-
-``` sh
-# example: using devour
-FZF_PLAYER="devour mpv"
-YTFZF_PLAYER_FORMAT="devour mpv --ytdl-format="
-```
 
 ## Todo 📝
 
 * [ ] Playlists
 * [ ] More sites
 * [x] Subscriptions
-* [x] Icons
+* [x] Thumbnails
 
 ## Bugs ❌
 
 * _dwm with swallow patch: Images don't render when looped (ie, option -l)_
-- _Sometimes thumbnails may not get previewed. This is likely an issue with ueberzug itself. Try deleting `.Xauthority` and relogging._
+- _If thubnails are not working `.Xautority` might be causing it. Try deleting `.Xauthority` and relogging._

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 	<a href="https://github.com/pystardust/ytfzf/graphs/contributors"><img src="https://img.shields.io/github/contributors/pystardust/ytfzf?style=flat-square"></a>
 	<a href="https://github.com/pystardust/ytfzf/releases/tag/v1.0.0"><img src="https://img.shields.io/github/v/tag/pystardust/ytfzf?style=flat-square"> </a>
 	<a href="https://github.com/pystardust/ytfzf/commits/master"><img src="https://img.shields.io/github/commit-activity/m/pystardust/ytfzf?color=green&style=flat-square"></a>
-	<a href="https://discord.gg/eE4WxBEC"><img src="https://img.shields.io/discord/815609275644117022?color=yellow&logo=discord&style=flat-square" alt="Discord"></a>
+	<a href="https://discord.gg/TM4xy6J3"><img src="https://img.shields.io/discord/815609275644117022?color=yellow&logo=discord&style=flat-square" alt="Discord"></a>
     <br />
     <br />
     <i>A POSIX script that helps you find Youtube videos (without API) and opens/downloads them using mpv/youtube-dl</i> 
@@ -20,116 +20,231 @@
 <img src=.assets/ytfzf.gif width="100%">
 </p>
 
-## Table of Contents
+<div style="float: left; width: 60%;">
+<h2>Table of Contents</h2>
+<ul>
+<li><a href="#Dependencies"><code>Dependencies</code></a></li>
+<li><a href="#Installation"><code>Installation</code></a></li>
+<li><a href="#Usage-Instructions"><code>Usage instruction</code></a></li>
+<li><a href="#Subscriptions"><code>Subscriptions</code></a></li>
+<li><a href="#Examples"><code>Examples</code></a></li>	
+</ul>
+</div>
+<div style="float: right; width: 40%;">
+<h2>Features</h2>
+<ul>
+<li>Thumbnails</li>
+<li>History</li>
+<li>Download</li>
+<li>Format selection</li>
+<li>Queue multiple videos</li>
+</ul>
+</div>
 
-- [`Features`](#Features)
-- [`Usage instruction`](#Usage-Instructions)
-- [`Examples`](#Examples)
-- [`Dependencies`](#Dependencies)
-- [`Installation`](#Installation)
+## Dependencies
 
-## Features
+_Fzf is optional, you can use an external menu (like dmenu) with the `-D` option (no thumbnail support)._
 
-* Thumbnails
-* History
-* Download
-* Format selection
-* Queue multiple videos
+* [`mpv`](https://github.com/mpv-player/mpv)
+* [`youtube-dl`](https://github.com/ytdl-org/youtube-dl)
+* [`jq`](https://github.com/stedolan/jq) - _to parse json_
+* [`fzf`](https://github.com/junegunn/fzf) (Optional) - _for menu_
+* [`ueberzug`](https://github.com/seebye/ueberzug) (Optional) - _for thumbnails_
+
+> Thumbnails only work with fzf and Ueberzug as of now.
+
++ #### Arch based
+
+	  sudo pacman -S jq mpv youtube-dl fzf
+
+	> For thumbnails
+
+	  sudo pacman -S ueberzug
+
++ #### Debian based
+
+	  sudo apt install jq mpv youtube-dl fzf
+
+	> For thumbnails
+
+	  pip install ueberzug
+
+	_Note youtube-dl is usually outdated in debian repos, I suggest getting it from  [youtube-dl github](https://github.com/ytdl-org/youtube-dl)_
+
++ #### MacOS
+
+	  brew install jq mpv youtube-dl fzf
+
+	_At the moment thumbnail previews aren't working on MacOS_
+
+
+## Installation
+
+#### Fast installation options
+
+_Those are three easy ways to install install the script. On some OS (such as MacOS) `Installation by direct download` might require you to change the installation path from  `/usr/bin/` to `/usr/local/bin/`_ 
+
+1. ##### Installation by direct download
+
+	```sh
+	sudo curl -L "https://raw.githubusercontent.com/pystardust/ytfzf/master/ytfzf" -o /usr/bin/ytfzf
+	sudo chmod +x /usr/bin/ytfzf
+	```
+
+2. ##### Arch users can install ytfzf from the [AUR](https://aur.archlinux.org/packages/ytfzf-git/)
+
+	```
+	yay -S ytfzf-git
+	```
+
+3. ##### Gentoo users can install ytfzf from the [nitratesky](https://github.com/VTimofeenko/nitratesky) overlay
+
+	```
+	eselect repository enable nitratesky
+	emerge -a1 net-misc/ytfzf
+	```
+
+#### Installation by cloning the repository 
+
+```sh
+git clone https://github.com/pystardust/ytfzf
+cd ytfzf
+```
+
++ **Install with the Makefile**
+
+```sh
+sudo make install
+```
+
++ **Uninstall with the Makefile**
+
+```sh
+sudo make uninstall
+```
 
 ## Usage-Instructions
+
+_You can create a configuration `~/.config/ytfzf/conf.sh`, and you can take inspiration from the example one [here](docs/conf.sh), or you can export the value for whicever value shown below_
 
 ```sh
 ytfzf [Options] <search-query>
 ```
 
-_Videos can be selected using fzf, dmenu or rofi._
-
 > To quit the script you can press `ESC` or `^C` in the video selection prompt.
 
-### **Config file**: 
-`~/.config/ytfzf/conf.sh`, [`example config file`](docs/conf.sh). 
++ ### Thumbnails
 
-***Any variable change mentioned below can be exported, or added to the config file.***
+	_Showing thumbnails requires ueberzug (which works only on X11), thous it is not supported on MacOS_.
+	
+	```sh
+	ytfzf -t <search-query>
+	```
+	
+	> Thumbnails preview side could be changed to the right with `--preview-side=right`
 
-### **Thumbnails**: 
-requires ueberzug (works only on X11), _doesn't work on wayland and macos_.
++ ### History
+	_Ytfzf save your history by default, more instructions are below_
 
-```sh
-ytfzf -t <search-query>
-```
+	- Show history
 
+		```sh
+		ytfzf -H
+		```
+	
+	- Clear history
+	
+		```sh
+		ytfzf -x
+		```
 
-> Thumbnails preview side could be changed to the right with `--preview-side=right`
+	- History file: `~/.cache/ytfzf/ytfzf_hst`
 
-### **History**: 
+	> History is enabled by default. To turn it off you can export `YTFZF_HIST=0` or set add it to the config file.
 
-```sh
-ytfzf -H
-```
++ ### External menu
 
-+ clear history
+	Use the `-D` flag: To use external menu
+	
+	By default the external menu is set to `dmenu -i -l 30`. This can be changed to `rofi`
+	
+	```sh
+	YTFZF_EXTMENU=' rofi -dmenu -fuzzy -width 1500'
+	```
+	
+	> The width of external menu can be adjusted with `YTFZF_EXTMENU_LEN=220`.
 
-```sh
-ytfzf -x
-```
++ ### Format-selction and download
 
-+ History file: `~/.cache/ytfzf/ytfzf_hst`
+	_Video format can be set as per [youtube-dl formatting](https://github.com/ytdl-org/youtube-dl#format-selection)._
+	
+	```sh
+	YTFZF_PREF="22"	# 22 set a resolution of 720p
+	```
 
-> History is enabled by default. To turn it off you can export `YTFZF_HIST=0` or set add it to the config file.
+	+ `-f`: To view and select available formats.
+	+ `-m`: (audio-only) Only audio format (best audio)
+	
+	+ `-d`: (download) To **download** a video instead of playing it.
+	
++ ### Multi-selection
+	
+	_Multiple videos can be queued up using `fzf`'s auto multi-selection (tab). To traverse between selected videos use `<` and `>`._
 
-### **External menu**
++ ### Looping, Searches
 
-	+ `-D`: To use external menu
+	+ `-l` --> (loop) would prompt the video menu every time a video finishes. Press `ESC` or `^C` to exit loop.
+	+ `-s` --> (search-again) would ask for another search query as the video ends.
 
-By default the external menu is set to `dmenu -i -l 30`. This can be changed to `rofi`
++ ### Auto and random selection
 
-```sh
-YTFZF_EXTMENU=' rofi -dmenu -fuzzy -width 1500'
-```
+	_To select videos *without video prompt*, if multiple videos are selected then they would play one after the other. The variable **n** represents the link count. Which is 1 by default._
+	
+	+ `-A`: (select-all) selects all the videos.
+	+ `-a`: (auto-selection) selects the first **n**(=1) result.
+	+ `-r`: (auto-selection) Randomly selects **n**(=1) results (shuffles them).
+	+ `-n <number>` : (link-count) Set **n** the number of links to be selected.
 
-> The width of external menu can be adjusted with `YTFZF_EXTMENU_LEN=220`.
++ ### Custom Player
+	
+	_By default, `ytfzf` uses `mpv`. Custom player should have the ability to launch youtube links (example: `vlc`)._
 
-### **Format-selction and download**
+	```sh
+	# example: using devour
+	FZF_PLAYER="devour mpv"
+	YTFZF_PLAYER_FORMAT="devour mpv --ytdl-format="
+	```
 
-Video format can be set as per [youtube-dl formatting](https://github.com/ytdl-org/youtube-dl#format-selection).
++ ### Misc
 
-```sh
-YTFZF_PREF="22"                   # 22 for 720p
-```
+	- The currently playing video details are stored in `~/.cache/ytfzf/ytfzf_cur` (for status bar modules)
+	
+	- Files and directories used by ytfzf can be set in the config file
+	
+	```sh
+	cache_dir="$HOME/.cache/ytfzf"
+	history_file="$YTFZF_CACHE/ytfzf_hst"
+	current_file="$YTFZF_CACHE/ytfzf_cur"
+	thumb_dir="$YTFZF_CACHE/thumb"
+	```
+	
+	#### Useful mpv key bindings
+	
+	- `f`    :  full screen
+	- `j`,`J`:  cycle subtitles (also works with audio, if the music video has subtitles)
+	- `L`    :  single-loop
+	
 
-+ `-f`: To view and select available formats.
-+ `-m`: (audio-only) Only audio format (best audio)
-
-+ `-d`: (download) To **download** a video instead of playing it.
-
-### **Multi-selection**: 
-Multiple videos can be queued up using `fzf`'s auto multi-selection (tab). To traverse between selected videos use `<` and `>`.
-
-### **Looping, Searches**
-
-+ `-l`: (loop) would prompt the video menu every time a video finishes. Press `ESC` or `^C` to exit loop.
-+ `-s`: (search-again) would ask for another search query as the video ends.
-
-### **Auto and random selection**
-To select videos *without video prompt*, if multiple videos are selected then they would play one after the other. The variable **n** represents the link count. Which is 1 by default.
-
-+ `-A`: (select-all) selects all the videos.
-+ `-a`: (auto-selection) selects the first **n**(=1) result.
-+ `-r`: (auto-selection) Randomly selects **n**(=1) results (shuffles them).
-
-+ `-n <number>` : (link-count) Set **n** the number of links to be selected.
-
-### **Subscriptions**
+## Subscriptions
 
 Subscriptions are managed in subscription file: `~/.config/ytfzf/subscriptions`.
+	#### Adding a certain channel to subscriptions
 
-#### Adding a certain channel to subscriptions
-	
-1. Open the channel page on a browser and go to the vidoes tab (located right below the channel name and subscription count).
-2. Copy the url of videos page. And add it to your subscription file.
-3. The url for each subscription must be on a separate line.
-	
-_The subscription file needs to have only the channels' video page url. Comments can be added with `#`_
+- Open the page of the channel you are interested in on a browser and go to the videos tab (located right below the channel name and subscription count).
+- Copy the url of videos page. And add it to your subscription file.
+- The url for each subscription must be on a separate line.
+
+**_The subscription file needs to have only the channels' video page url. Comments can be added with `#`_**
 
 ```
 # file : ~/.config/ytfzf/subscriptions
@@ -139,8 +254,8 @@ https://www.youtube.com/channel/UCngn7SVujlvskHRvRKc1cTw/videos # bugswriter
 https://www.youtube.com/c/DistroTube/videos                     # distrotube
 https://www.youtube.com/c/MentalOutlaw/videos                   # mental outlaw
 ```
-	
-To see subscriptions' latest videos
+
+**_To see subscriptions' latest videos_**
 
 ```sh
 # Defaults to 10 results from each channel
@@ -150,43 +265,13 @@ ytfzf -S
 ytfzf --subs=15
 ```
 
-_This can be combined with other options like thumbnails_
+**_This can be combined with other options like thumbnails_**
 
 ```sh
 ytfzf -tS
 ```
 
-### **Custom Player**
-By default, `ytfzf` uses `mpv`. Custom player should have the ability to launch youtube links (example: `vlc`).
-
-```sh
-# example: using devour
-FZF_PLAYER="devour mpv"
-YTFZF_PLAYER_FORMAT="devour mpv --ytdl-format="
-```
-
-
-### **Misc**
-
-+ The currently playing video details are stored in `~/.cache/ytfzf_cur` (for status bar modules)
-
-+ Files and directories used by ytfzf can be set in the config file
-
-```sh
-cache_dir="$HOME/.cache/ytfzf"
-history_file="$YTFZF_CACHE/ytfzf_hst"
-current_file="$YTFZF_CACHE/ytfzf_cur"
-thumb_dir="$YTFZF_CACHE/thumb"
-```
-
-### Useful mpv key bindings
-
-- `f`    :  full screen
-- `j`,`J`:  cycle subtitles (also works with audio, if the music video has subtitles)
-- `L`    :  single-loop
-
 ## Examples
-
 +  Search with Thumbnails
 
 	> Find and watch videos with thumbnail previews
@@ -216,91 +301,14 @@ first hit Q to save position and quit mpv, then choose your format using_
 
 	  ytfzf -faH
 
+## Update Log
 
-
-### Update log
-
-- Subscriptions
-- Now ytfzf can queue videos using fzf multiselect option. Press tab to select a video. All the videos will be lined up in mpv. Use `>` and `<` to traverse them.
-- Make continuous queries with `-s`
-- Thumbnails! Using Ueberzug. Inspired by [`fontpreview-ueberzug`](https://github.com/OliverLew/fontpreview-ueberzug).
-- added MacOS support
-- Stdin can be taken by using `ytfzf -`, for both fzf and external menu.
-
-## Dependencies
-
-_Fzf is optional, you can use an external menu (like dmenu) with the `-D` option (no thumbnail support)._
-
-* [`mpv`](https://github.com/mpv-player/mpv)
-* [`youtube-dl`](https://github.com/ytdl-org/youtube-dl)
-* [`fzf`](https://github.com/junegunn/fzf) (Optional) - _for menu_
-* [`jq`](https://github.com/stedolan/jq) - _to parse json_
-* [`ueberzug`](https://github.com/seebye/ueberzug) (Optional) - _for thumbnails_
-
-> Thumbnails only work with fzf and Ueberzug as of now.
-
-
-+ ### Arch based
-
-	  sudo pacman -S jq mpv youtube-dl fzf
-
-	> For thumbnails
-
-	  sudo pacman -S ueberzug
-
-+ ### Debian based
-
-	  sudo apt install jq mpv youtube-dl fzf
-
-	> For thumbnails
-
-	  pip install ueberzug
-
-	_Note youtube-dl is usually outdated in debian repos, I suggest getting it from  [youtube-dl github](https://github.com/ytdl-org/youtube-dl)_
-
-+ ### MacOS
-
-	  brew install jq mpv youtube-dl fzf
-
-	_At the moment thumbnail previews aren't working on MacOS_
-
-
-## Installation
-
-#### Installation by direct download
-
-```sh
-sudo curl -L "https://raw.githubusercontent.com/pystardust/ytfzf/master/ytfzf" -o /usr/bin/ytfzf
-sudo chmod +x /usr/bin/ytfzf
-```
-
-#### Installation by cloning the repository
-
-```sh
-git clone https://github.com/pystardust/ytfzf
-cd ytfzf
-```
-
-+ Install with the Makefile
-
-```sh
-sudo make install
-```
-
-+ Uninstall with the Makefile
-
-```sh
-sudo make uninstall
-```
-
-#### Arch users can install ytfzf from the [AUR](https://aur.archlinux.org/packages/ytfzf-git/)
-
-		yay -S ytfzf-git
-
-#### Gentoo users can install ytfzf from the [nitratesky](https://github.com/VTimofeenko/nitratesky) overlay
-
-		eselect repository enable nitratesky
-		emerge -a1 net-misc/ytfzf
+* We have now added Subscriptions which allows you to search between videos of subscribed channels easily
+* Now ytfzf can queue videos using fzf multiselect option. Press tab to select a video. All the videos will be lined up in mpv. Use `>` and `<` to traverse them.
+* Make continuous queries with `-s`
+* You can preview video thumbnails now! Using Ueberzug. Inspired by [`fontpreview-ueberzug`](https://github.com/OliverLew/fontpreview-ueberzug).
+* Stdin can be taken by using `ytfzf -`, for both fzf and external menu.
+* Added MacOS support
 
 
 ## Todo 📝

--- a/README.md
+++ b/README.md
@@ -269,11 +269,12 @@ https://www.youtube.com/c/MentalOutlaw/videos                   #mental outlaw
 
 ```
 ytfzf -S
+# Defaults to 10 results from each channel
+ytfzf --sub=15
+# To show 15 results instead
 ```
 
-This
-
-_This can be combined with other options like thumbnails, auto play_
+_This can be combined with other options like thumbnails_
 ```
 ytfzf -tS
 ```

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ https://www.youtube.com/c/MentalOutlaw/videos                   #mental outlaw
 
 + #### To see subscriptions latest videos
 
-```
+```sh
 ytfzf -S
 # Defaults to 10 results from each channel
 ytfzf --sub=15
@@ -275,7 +275,7 @@ ytfzf --sub=15
 ```
 
 _This can be combined with other options like thumbnails_
-```
+```sh
 ytfzf -tS
 ```
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ https://www.youtube.com/c/MentalOutlaw/videos                   #mental outlaw
 ```sh
 ytfzf -S
 # Defaults to 10 results from each channel
-ytfzf --sub=15
+ytfzf --subs=15
 # To show 15 results instead
 ```
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,8 @@ YTFZF_PLAYER_FORMAT="devour mpv --ytdl-format="
 ## Todo 📝
 
 * [ ] Playlists
-* [ ] Comments
+* [ ] More sites
+* [x] Subscriptions
 * [x] Icons
 
 ## Bugs ❌

--- a/README.md
+++ b/README.md
@@ -48,42 +48,50 @@ _Videos can be selected using fzf, dmenu or rofi._
 
 > To quit the script you can press `ESC` or `^C` in the video selection prompt.
 
-+ **Config file**: `~/.config/ytfzf/conf.sh`, [`example config file`](docs/conf.sh). 
++ #### **Config file**: 
+`~/.config/ytfzf/conf.sh`, [`example config file`](docs/conf.sh). 
 
 ***Any variable change mentioned below can be exported, or added to the config file.***
 
-+ **Thumbnails**: requires ueberzug (works only on X11), _doesn't work on wayland and macos_
++ #### **Thumbnails**: 
+requires ueberzug (works only on X11), _doesn't work on wayland and macos_
 
+	```sh
 	ytfzf -t <search-query>
+	```
 
 
 > Thumbnails preview side could be changed to the right with `--preview-side=right`
 
-+ **History**: 
++ #### **History**: 
 
+	```sh
 	ytfzf -H
+	```
 
 	+ clear history
 
+	```sh
 	ytfzf -x
+	```
 
 	+ History file: `~/.cache/ytfzf/ytfzf_hst`
 
 > History is enabled by default. To turn it off you can export `YTFZF_HIST=0` or set add it to the config file.
 
-+ **External menu**
++ #### **External menu**
 
 	+ `-D`: To use external menu
 
-	+ By default the external menu is set to `dmenu -i -l 30`. This can be changed to `rofi`
+By default the external menu is set to `dmenu -i -l 30`. This can be changed to `rofi`
 
 	```sh
 	YTFZF_EXTMENU=' rofi -dmenu -fuzzy -width 1500'
 	```
 
-	+ The width of external menu can be adjusted with `YTFZF_EXTMENU_LEN=220`.
+> The width of external menu can be adjusted with `YTFZF_EXTMENU_LEN=220`.
 
-+ **Format-selction and download**
++ #### **Format-selction and download**
 
 	+ Video format can be set as per [youtube-dl formatting](https://github.com/ytdl-org/youtube-dl#format-selection).
 
@@ -96,14 +104,15 @@ _Videos can be selected using fzf, dmenu or rofi._
 
 	+ `-d`: (download) To **download** a video instead of playing it.
 
-+ **Multi-selection**: multiple videos can be queued up using `fzf`'s auto multi-selection (tab). To traverse between selected videos use `<` and `>`.
++ #### **Multi-selection**: 
+multiple videos can be queued up using `fzf`'s auto multi-selection (tab). To traverse between selected videos use `<` and `>`.
 
-+ **Looping, Searches**
++ #### **Looping, Searches**
 
 	+ `-l`: (loop) would prompt the video menu every time a video finishes. Press `ESC` or `^C` to exit loop.
 	+ `-s`: (search-again) would ask for another search query as the video ends.
 
-+ **Auto and random selection**
++ #### **Auto and random selection**
 To select videos *without video prompt*, if multiple videos are selected then they would play one after the other. The variable **n** represents the link count. Which is 1 by default.
 
 	+ `-A`: (select-all) selects all the videos.
@@ -112,7 +121,7 @@ To select videos *without video prompt*, if multiple videos are selected then th
 
 	+ `-n <number>` : (link-count) Set **n** the number of links to be selected.
 
-+ **Subscriptions**
++ #### **Subscriptions**
 
 Subscriptions are managed in subscription file: `~/.config/ytfzf/subscriptions`.
 
@@ -127,13 +136,13 @@ _The subscription file needs to have only the channels' video page url. Comments
 	```
 	# file : ~/.config/ytfzf/subscriptions
 	## tech channels
-	https://www.youtube.com/c/LukeSmithxyz/videos                   #luke smith
-	https://www.youtube.com/channel/UCngn7SVujlvskHRvRKc1cTw/videos #bugswriter
-	https://www.youtube.com/c/DistroTube/videos                     #distrotube
-	https://www.youtube.com/c/MentalOutlaw/videos                   #mental outlaw
+	https://www.youtube.com/c/LukeSmithxyz/videos                   # luke smith
+	https://www.youtube.com/channel/UCngn7SVujlvskHRvRKc1cTw/videos # bugswriter
+	https://www.youtube.com/c/DistroTube/videos                     # distrotube
+	https://www.youtube.com/c/MentalOutlaw/videos                   # mental outlaw
 	```
 	
-	+ To see subscriptions' latest videos
+To see subscriptions' latest videos
 	
 	```sh
 	# Defaults to 10 results from each channel
@@ -144,11 +153,12 @@ _The subscription file needs to have only the channels' video page url. Comments
 	```
 	
 _This can be combined with other options like thumbnails_
+
 	```sh
 	ytfzf -tS
 	```
 
-+ **Custom Player**
++ #### **Custom Player**
 By default, `ytfzf` uses `mpv`. Custom player should have the ability to launch youtube links (example: `vlc`).
 
 	```sh
@@ -158,7 +168,7 @@ By default, `ytfzf` uses `mpv`. Custom player should have the ability to launch 
 	```
 
 
-+ **Misc**
++ #### **Misc**
 
 	+ The currently playing video details are stored in `~/.cache/ytfzf_cur` (for status bar modules)
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ first hit Q to save position and quit mpv, then choose your format using_
 
 ### Update log
 
+- Subscriptions
 - Now ytfzf can queue videos using fzf multiselect option. Press tab to select a video. All the videos will be lined up in mpv. Use `>` and `<` to traverse them.
 - Make continuous queries with `-s`
 - Thumbnails! Using Ueberzug. Inspired by [`fontpreview-ueberzug`](https://github.com/OliverLew/fontpreview-ueberzug).
@@ -243,6 +244,41 @@ _Default configuration can be set in the configuration file `~/.config/ytfzf/con
 	```
 
 	_If the preferred format is not available then it will revert back to auto selection._ [_Documentation for ytdl formats_](https://github.com/ytdl-org/youtube-dl#format-selection)
+
+## Subscriptions
+
+_Subscriptions are managed in subscription file: `~/.config/ytfzf/subscriptions`._
+
++ #### Adding a certain channel to your subscriptions. 
+
+1. Open the channel page on a browser and go to the vidoes tab (located right below the channel name and subscription count).
+2. Copy the url of videos page. And add it to your subscription file.
+3. The url for each subscription must be on a separate line.
+
+_The subscription file needs to have only the channels' video page url. Comments can be added with `#`_
+```
+# file : ~/.config/ytfzf/subscriptions
+## tech channels
+https://www.youtube.com/c/LukeSmithxyz/videos                   #luke smith
+https://www.youtube.com/channel/UCngn7SVujlvskHRvRKc1cTw/videos #bugswriter
+https://www.youtube.com/c/DistroTube/videos                     #distrotube
+https://www.youtube.com/c/MentalOutlaw/videos                   #mental outlaw
+```
+
++ #### To see subscriptions latest videos
+
+```
+ytfzf -S
+```
+
+This
+
+_This can be combined with other options like thumbnails, auto play_
+```
+ytfzf -tS
+```
+
+
 
 ## External-menu command
 

--- a/README.md
+++ b/README.md
@@ -267,37 +267,37 @@ _Fzf is optional, you can use an external menu (like dmenu) with the `-D` option
 
 ## Installation
 
-### Installation by direct download
+#### Installation by direct download
 
-	```sh
-	sudo curl -L "https://raw.githubusercontent.com/pystardust/ytfzf/master/ytfzf" -o /usr/bin/ytfzf
-	sudo chmod +x /usr/bin/ytfzf
-	```
+```sh
+sudo curl -L "https://raw.githubusercontent.com/pystardust/ytfzf/master/ytfzf" -o /usr/bin/ytfzf
+sudo chmod +x /usr/bin/ytfzf
+```
 
 #### Installation by cloning the repository
 
-	```sh
-	git clone https://github.com/pystardust/ytfzf
-	cd ytfzf
-	```
+```sh
+git clone https://github.com/pystardust/ytfzf
+cd ytfzf
+```
 
-	- ##### Install with the Makefile
++ Install with the Makefile
 
-		```sh
-		sudo make install
-		```
+```sh
+sudo make install
+```
 
-	- ##### Uninstall with the Makefile
++ Uninstall with the Makefile
 
-		```sh
-		sudo make uninstall
-		```
+```sh
+sudo make uninstall
+```
 
-### Arch users can install ytfzf from the [AUR](https://aur.archlinux.org/packages/ytfzf-git/)
+#### Arch users can install ytfzf from the [AUR](https://aur.archlinux.org/packages/ytfzf-git/)
 
 		yay -S ytfzf-git
 
-### Gentoo users can install ytfzf from the [nitratesky](https://github.com/VTimofeenko/nitratesky) overlay
+#### Gentoo users can install ytfzf from the [nitratesky](https://github.com/VTimofeenko/nitratesky) overlay
 
 		eselect repository enable nitratesky
 		emerge -a1 net-misc/ytfzf

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@
 
 ## Table of Contents
 
-_These links will take you where you want to go with the snap of a finger_
-
 - [`Features`](#Features)
 - [`Usage instruction`](#Usage-Instructions)
 - [`Examples`](#Examples)
@@ -48,137 +46,138 @@ _Videos can be selected using fzf, dmenu or rofi._
 
 > To quit the script you can press `ESC` or `^C` in the video selection prompt.
 
-+ #### **Config file**: 
+### **Config file**: 
 `~/.config/ytfzf/conf.sh`, [`example config file`](docs/conf.sh). 
 
 ***Any variable change mentioned below can be exported, or added to the config file.***
 
-+ #### **Thumbnails**: 
-requires ueberzug (works only on X11), _doesn't work on wayland and macos_
+### **Thumbnails**: 
+requires ueberzug (works only on X11), _doesn't work on wayland and macos_.
 
-	```sh
-	ytfzf -t <search-query>
-	```
+```sh
+ytfzf -t <search-query>
+```
 
 
 > Thumbnails preview side could be changed to the right with `--preview-side=right`
 
-+ #### **History**: 
+### **History**: 
 
-	```sh
-	ytfzf -H
-	```
+```sh
+ytfzf -H
+```
 
-	+ clear history
++ clear history
 
-	```sh
-	ytfzf -x
-	```
+```sh
+ytfzf -x
+```
 
-	+ History file: `~/.cache/ytfzf/ytfzf_hst`
++ History file: `~/.cache/ytfzf/ytfzf_hst`
 
 > History is enabled by default. To turn it off you can export `YTFZF_HIST=0` or set add it to the config file.
 
-+ #### **External menu**
+### **External menu**
 
 	+ `-D`: To use external menu
 
 By default the external menu is set to `dmenu -i -l 30`. This can be changed to `rofi`
 
-	```sh
-	YTFZF_EXTMENU=' rofi -dmenu -fuzzy -width 1500'
-	```
+```sh
+YTFZF_EXTMENU=' rofi -dmenu -fuzzy -width 1500'
+```
 
 > The width of external menu can be adjusted with `YTFZF_EXTMENU_LEN=220`.
 
-+ #### **Format-selction and download**
+### **Format-selction and download**
 
-	+ Video format can be set as per [youtube-dl formatting](https://github.com/ytdl-org/youtube-dl#format-selection).
+Video format can be set as per [youtube-dl formatting](https://github.com/ytdl-org/youtube-dl#format-selection).
 
-	```sh
-	YTFZF_PREF="22"                   # 22 for 720p
-	```
+```sh
+YTFZF_PREF="22"                   # 22 for 720p
+```
 
-	+ `-f`: To view and select available formats.
-	+ `-m`: (audio-only) Only audio format (best audio)
++ `-f`: To view and select available formats.
++ `-m`: (audio-only) Only audio format (best audio)
 
-	+ `-d`: (download) To **download** a video instead of playing it.
++ `-d`: (download) To **download** a video instead of playing it.
 
-+ #### **Multi-selection**: 
-multiple videos can be queued up using `fzf`'s auto multi-selection (tab). To traverse between selected videos use `<` and `>`.
+### **Multi-selection**: 
+Multiple videos can be queued up using `fzf`'s auto multi-selection (tab). To traverse between selected videos use `<` and `>`.
 
-+ #### **Looping, Searches**
+### **Looping, Searches**
 
-	+ `-l`: (loop) would prompt the video menu every time a video finishes. Press `ESC` or `^C` to exit loop.
-	+ `-s`: (search-again) would ask for another search query as the video ends.
++ `-l`: (loop) would prompt the video menu every time a video finishes. Press `ESC` or `^C` to exit loop.
++ `-s`: (search-again) would ask for another search query as the video ends.
 
-+ #### **Auto and random selection**
+### **Auto and random selection**
 To select videos *without video prompt*, if multiple videos are selected then they would play one after the other. The variable **n** represents the link count. Which is 1 by default.
 
-	+ `-A`: (select-all) selects all the videos.
-	+ `-a`: (auto-selection) selects the first **n**(=1) result.
-	+ `-r`: (auto-selection) Randomly selects **n**(=1) results (shuffles them).
++ `-A`: (select-all) selects all the videos.
++ `-a`: (auto-selection) selects the first **n**(=1) result.
++ `-r`: (auto-selection) Randomly selects **n**(=1) results (shuffles them).
 
-	+ `-n <number>` : (link-count) Set **n** the number of links to be selected.
++ `-n <number>` : (link-count) Set **n** the number of links to be selected.
 
-+ #### **Subscriptions**
+### **Subscriptions**
 
 Subscriptions are managed in subscription file: `~/.config/ytfzf/subscriptions`.
 
-	+ Adding a certain channel to subscriptions
+#### Adding a certain channel to subscriptions
 	
-	1. Open the channel page on a browser and go to the vidoes tab (located right below the channel name and subscription count).
-	2. Copy the url of videos page. And add it to your subscription file.
-	3. The url for each subscription must be on a separate line.
+1. Open the channel page on a browser and go to the vidoes tab (located right below the channel name and subscription count).
+2. Copy the url of videos page. And add it to your subscription file.
+3. The url for each subscription must be on a separate line.
 	
 _The subscription file needs to have only the channels' video page url. Comments can be added with `#`_
 
-	```
-	# file : ~/.config/ytfzf/subscriptions
-	## tech channels
-	https://www.youtube.com/c/LukeSmithxyz/videos                   # luke smith
-	https://www.youtube.com/channel/UCngn7SVujlvskHRvRKc1cTw/videos # bugswriter
-	https://www.youtube.com/c/DistroTube/videos                     # distrotube
-	https://www.youtube.com/c/MentalOutlaw/videos                   # mental outlaw
-	```
+```
+# file : ~/.config/ytfzf/subscriptions
+## tech channels
+https://www.youtube.com/c/LukeSmithxyz/videos                   # luke smith
+https://www.youtube.com/channel/UCngn7SVujlvskHRvRKc1cTw/videos # bugswriter
+https://www.youtube.com/c/DistroTube/videos                     # distrotube
+https://www.youtube.com/c/MentalOutlaw/videos                   # mental outlaw
+```
 	
 To see subscriptions' latest videos
-	
-	```sh
-	# Defaults to 10 results from each channel
-	ytfzf -S
 
-	# To show 15 results instead
-	ytfzf --subs=15
-	```
-	
+```sh
+# Defaults to 10 results from each channel
+ytfzf -S
+
+# To show 15 results instead
+ytfzf --subs=15
+```
+
 _This can be combined with other options like thumbnails_
 
-	```sh
-	ytfzf -tS
-	```
+```sh
+ytfzf -tS
+```
 
-+ #### **Custom Player**
+### **Custom Player**
 By default, `ytfzf` uses `mpv`. Custom player should have the ability to launch youtube links (example: `vlc`).
 
-	```sh
-	# example: using devour
-	FZF_PLAYER="devour mpv"
-	YTFZF_PLAYER_FORMAT="devour mpv --ytdl-format="
-	```
+```sh
+# example: using devour
+FZF_PLAYER="devour mpv"
+YTFZF_PLAYER_FORMAT="devour mpv --ytdl-format="
+```
 
 
-+ #### **Misc**
+### **Misc**
 
-	+ The currently playing video details are stored in `~/.cache/ytfzf_cur` (for status bar modules)
++ The currently playing video details are stored in `~/.cache/ytfzf_cur` (for status bar modules)
 
-	+ Files and directories used by ytfzf can be set in the config file
-	```sh
-	cache_dir="$HOME/.cache/ytfzf"
-	history_file="$YTFZF_CACHE/ytfzf_hst"
-	current_file="$YTFZF_CACHE/ytfzf_cur"
-	thumb_dir="$YTFZF_CACHE/thumb"
-	```
++ Files and directories used by ytfzf can be set in the config file
+
+```sh
+cache_dir="$HOME/.cache/ytfzf"
+history_file="$YTFZF_CACHE/ytfzf_hst"
+current_file="$YTFZF_CACHE/ytfzf_cur"
+thumb_dir="$YTFZF_CACHE/thumb"
+```
 
 ### Useful mpv key bindings
 
@@ -268,14 +267,14 @@ _Fzf is optional, you can use an external menu (like dmenu) with the `-D` option
 
 ## Installation
 
-+ #### Installation by direct download
+### Installation by direct download
 
 	```sh
 	sudo curl -L "https://raw.githubusercontent.com/pystardust/ytfzf/master/ytfzf" -o /usr/bin/ytfzf
 	sudo chmod +x /usr/bin/ytfzf
 	```
 
-+ #### Installation by cloning the repository
+#### Installation by cloning the repository
 
 	```sh
 	git clone https://github.com/pystardust/ytfzf
@@ -294,11 +293,11 @@ _Fzf is optional, you can use an external menu (like dmenu) with the `-D` option
 		sudo make uninstall
 		```
 
-+ #### Arch users can install ytfzf from the [AUR](https://aur.archlinux.org/packages/ytfzf-git/)
+### Arch users can install ytfzf from the [AUR](https://aur.archlinux.org/packages/ytfzf-git/)
 
 		yay -S ytfzf-git
 
-+ #### Gentoo users can install ytfzf from the [nitratesky](https://github.com/VTimofeenko/nitratesky) overlay
+### Gentoo users can install ytfzf from the [nitratesky](https://github.com/VTimofeenko/nitratesky) overlay
 
 		eselect repository enable nitratesky
 		emerge -a1 net-misc/ytfzf

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -71,7 +71,7 @@ enable_fzf_default_opts=0
 #any variables here can be set with options when running the command
 #see ytfzf --help for more info
 
-#enable/disable using the external menu
+#enable/disable using $external_menu
 #same as -D
 is_ext_menu=0
 
@@ -105,11 +105,11 @@ show_format=0
 
 #the side to show thumbnails
 #options are "left", "right", "top", "bottom"
-#same as --previews=
+#same as --priview-side=
 preview_side="left"
 
 #the amount of links to get from each subscription
-#same as --sub=
+#same as --subs=
 sub_link_count=10
 
 #whether or not to show --------------channel---------------- when viewing subscriptions
@@ -175,6 +175,23 @@ current_file="$YTFZF_CACHE/ytfzf_cur"
 thumb_dir="$YTFZF_CACHE/thumb"
 
 #when displaying thumbnails, use the text printed in this function to show the title, views, etc..
+#available default colors (note: they are be bolded):
+    #c_red
+    #c_green
+    #c_yellow
+    #c_blue
+    #c_magenta
+    #c_cyan
+    #c_reset (sets it back to terminal defaults)
+#available variables
+    #title
+    #channel
+    #duration
+    #views
+    #date (video upload date)
+    #shorturl (the video ID)
+#how this works:
+    #anything printed will stay on the screen in the fzf preview menu
 thumbnail_video_info_text () {
          printf "\n${c_cyan}%s" "$title"
          printf "\n${c_blue}Channel      ${c_green}%s" "$channel"

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -108,6 +108,20 @@ show_format=0
 #same as --previews=
 preview_side="left"
 
+#the amount of links to get from each subscription
+#same as --sub=
+sub_link_count=10
+
+#whether or not to show --------------channel---------------- when viewing subscriptions
+#same as --fancy-subs=
+fancy_subscriptions_menu=1
+
+#where to source videos from
+#options are history, yt_subs, yt_search
+#history is the same as -H
+#yt_subs is the same as -S
+scrape="yt_search"
+
 #the filter id that will be used when searching youtube
 #same as --filter-id={filter}
 #to get a filter id go to youtube search for something, choose the filter you want,

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -171,6 +171,9 @@ history_file="$YTFZF_CACHE/ytfzf_hst"
 #the file for writing the menu option that was chosen
 current_file="$YTFZF_CACHE/ytfzf_cur"
 
+#the folder where thumbnails are cached
+thumb_dir="$YTFZF_CACHE/thumb"
+
 #when displaying thumbnails, use the text printed in this function to show the title, views, etc..
 thumbnail_video_info_text () {
          printf "\n${c_cyan}%s" "$title"

--- a/ytfzf
+++ b/ytfzf
@@ -456,7 +456,7 @@ get_video_data () {
 }
 
 scrape_subscriptions () {
-	for link in https://www.youtube.com/c/DistroTube/videos https://www.youtube.com/user/PewDiePie/videos; do
+	for link in $*; do
 	    echo "Fetching $link" 
 	    get_yt_html "$link"
 	    #gets the channel name from title of page

--- a/ytfzf
+++ b/ytfzf
@@ -335,7 +335,7 @@ stop_ueberzug () {
     rm "$FIFO" > /dev/null 2>&1
 }
 
-if ! type thumbnail_video_info_text > /dev/null; then
+if ! type thumbnail_video_info_text > /dev/null 2>&1 ; then
     thumbnail_video_info_text () {
 	printf "\n${c_cyan}%s" "$title"
 	printf "\n${c_blue}Channel	${c_green}%s" "$channel"

--- a/ytfzf
+++ b/ytfzf
@@ -743,6 +743,14 @@ EOF
 	videos_data="$(cat "$tmp_video_data_file")"
 }
 
+is_non_number () {
+    if [ -n "$(echo "$1" | grep -o '[^0-9]')" ]; then
+	return 0 
+    else
+	return 1
+    fi
+}
+
 bad_opt_arg () {
 	opt="$1"
 	arg="$2"
@@ -758,6 +766,9 @@ parse_long_opt () {
 	        help) parse_opt "h" ;;
 
 		ext-menu) parse_opt "D" ;;
+		ext-menu=*) 
+		    parse_opt "D" "${opt#*=}"
+		    is_non_number "$is_ext_menu" && bad_opt_arg "--ext-menu=" "$is_ext_menu" ;;
 
 		download) parse_opt "d" ;;
 
@@ -765,25 +776,44 @@ parse_long_opt () {
 
 		clear-history) parse_opt "x" ;;
 
-		random-select) parase_opt "r" ;;
 		search) parse_opt "s" ;;
-
+		search=*) 
+		    parse_opt "s" "${opt#*=}"
+		    is_non_number "$search_again" && bad_opt_arg "--search=" "$search_again" ;;
 
 		loop) parse_opt "l" ;;
+		loop=*) 
+		    parse_opt "l" "${opt#*=}"
+		    is_non_number "$YTFZF_LOOP" && bad_opt_arg "--loop=" "$YTFZF_LOOP" ;;
 
 		thumbnails) parse_opt "t" ;;
+		thumbnails=*) 
+		    parse_opt "t" "${opt#*=}" 
+		    is_non_number "$show_thumbnails" && bad_opt_arg "--thumbnails=" "$show_thumbnails" ;;
 
 		link-only) parse_opt "L" ;;
+		link-only=*) 
+		    parse_opt "L" "${opt#*=}"
+		    is_non_number "$show_link_only" && bad_opt_arg "--link-only=" "$show_link_only" ;;
 
 		video-count=*) parse_opt "n" "${opt#*=}" ;;
 
 		audio-only) parse_opt "m" ;;
 
 		auto-play) parse_opt "a" ;;
+		auto-play=*) 
+		    parse_opt "a" "${opt#*=}"
+		    is_non_number "$auto_select" && bad_opt_arg "--auto-play=" "$auto_select" ;;
     
 		select-all) parse_opt "A" ;;
+		select-all=*) 
+		    parse_opt "A" "${opt#*=}"
+		    is_non_number "$select_all" && bad_opt_arg "--select-all=" "$select_all" ;;
 
-		random-auto-play) parse_opt "r" ;;
+		random-play) parse_opt "r" ;;
+		random-play=*) 
+		    parse_opt "r" "${opt#*=}"
+		    is_non_number "$random_select" && bad_opt_arg "--random-play=" "$random_select" ;;
 
 		upload-time=*) upload_date_filter="${opt#*=}" ;;
 		last-hour) upload_date_filter="last-hour" ;;
@@ -799,7 +829,6 @@ parse_long_opt () {
 
 		filter-id=*|sp=*) sp="${opt#*=}" ;;
 
-
 		previews=*) export PREVIEW_SIDE="${opt#*=}" ;;
 
 		update) update_ytfzf "master" ;;
@@ -808,9 +837,7 @@ parse_long_opt () {
 		sub) parse_opt "S" ;;
 		sub=*)	
 			sub_link_count="${opt#*=}" 
-			if [ -n "$(echo "$sub_link_count" | grep -o '[^0-9]')" ]; then
-				bad_opt_arg "--sub" "$sub_link_count"
-			fi
+			is_non_number "$sub_link_count" && bad_opt_arg "--sub" "$sub_link_count"
 			parse_opt "S"
 			;;
 
@@ -841,7 +868,7 @@ parse_opt () {
 		h) 	helpinfo
 			exit ;;
 
-		D) 	is_ext_menu="1" ;;
+		D) 	is_ext_menu="${OPTARG:-1}" ;;
 
 		m) 	YTFZF_PREF="bestaudio" ;;
 
@@ -854,29 +881,28 @@ parse_opt () {
 
 		x)	clear_history && exit ;;
 
-		a) 	auto_select=1 ;;
-		A)	select_all=1 ;;
+		a)	auto_select=${OPTARG:-1} ;;
 
-		r)	random_select=1 ;;
+		A)	select_all=${OPTARG:-1} ;;
 
-		s)	search_again=1 ;;
+		r)	random_select=${OPTARG:-1} ;;
+
+		s)	search_again=${OPTARG:-1} ;;
 
 		S)	scrape="yt_subs" ;;
 
-		l) 	YTFZF_LOOP=1 ;;
+		l) 	YTFZF_LOOP=${OPTARG:-1} ;;
 
-		t) 	show_thumbnails=1 ;;
+		t) 	show_thumbnails=${OPTARG:-1} ;;
 
 		v)	printf "ytfzf: %s\n" "$YTFZF_VERSION"
 			exit ;;
 
-		L) 	show_link_only=1 ;;
+		L) 	show_link_only=${OPTARG:-1} ;;
 
 		n)	
 		    link_count="$OPTARG" 
-		    if [ -n "$(echo "$link_count" | grep -o '[^0-9]')" ]; then
-			bad_opt_arg "-n" "$link_count"
-		    fi ;;
+		    is_non_number "$link_count" && bad_opt_arg "-n" "$link_count" ;;
 
 		U) 	[ -p "$FIFO" ] && preview_img "$OPTARG"; exit;
 			# This option is reserved for the script, to show image previews

--- a/ytfzf
+++ b/ytfzf
@@ -354,14 +354,12 @@ download_thumbnails () {
 			name="$line"
 			{ 
 				curl -s "$url" > "$thumb_dir/$name.png" 
-				[ "$show_link_only" -eq 0 ] && printf "."; 
 			} &
 		fi
 		i=$((i + 1))
 	done << EOF
 $thumb_urls
 EOF
-	wait && [ "$show_link_only" -eq 0 ] && echo ""
 
 }
 get_sp_filter () {
@@ -469,11 +467,12 @@ scrape_channel () {
 	    }
 	]')"
 	
-	videos_data="$(get_video_data "$videos_json")"
+	videos_data="$(printf "\n%s\n%s\n" "--------------------${channel_name}------------------------------------------------------" \
+		"$(get_video_data "$videos_json")" )"
 	
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Make sure the link is correct.\n"; exit 1;}
-	printf "%s" "$videos_data\n" >> "$tmp_video_data_file"
+	printf "%s" "$videos_data" >> "$tmp_video_data_file"
 	
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 }
@@ -526,6 +525,7 @@ scrape_yt () {
 	printf "%s" "$videos_data\n" >> "$tmp_video_data_file"
 
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
+	wait
 }
 
 

--- a/ytfzf
+++ b/ytfzf
@@ -91,8 +91,6 @@ link_count=${link_count-1}
 search_again=${search_again-0}
 #filter id used when searching
 sp="${sp-}"
-# Gets subscriptions from sub file if 1
-is_get_subscriptions=0
 #ueberzug related variables
 #the side where thumbnails are shown
 #needs to be exported because ueberzug spawns subprocesses
@@ -653,7 +651,7 @@ check_if_url () {
 	if { echo "$1" | grep -q "$url_regex"; } ; then
 		is_url=1
 		urls="$1"
-		scrape=0
+		scrape=""
 	else
 		is_url=0
 	fi
@@ -667,7 +665,6 @@ get_history () {
 		[ -z "$hist_data" ] && printf "History is empty!\n" && exit;
 		#removes duplicate values from $history_data
 		videos_data="$(echo "$hist_data" | uniq )"
-		scrape=0
 	else
 		printf "History is not enabled. Please enable it to use this option (-H).\n";
 		exit;
@@ -697,8 +694,7 @@ update_ytfzf () {
 	exit
 }
 
-get_subscriptions () {
-	scrape=0
+scrape_subscriptions () {
 	while read -r url; do
 		 scrape_channel "$url"  &
 	done < "$subscriptions_file"
@@ -707,7 +703,7 @@ get_subscriptions () {
 }
 
 #is used to know whether or not scraping the search page is necessary
-scrape=1
+scrape="yt_search"
 #OPT
 parse_long_opt () {
 	opt="$1"
@@ -796,7 +792,7 @@ parse_opt () {
 
 		f) 	show_format=1 ;;
 
-		H)	get_history ;;
+		H)	scrape="history" ;;
 
 		x)	clear_history && exit ;;
 
@@ -807,7 +803,7 @@ parse_opt () {
 
 		s)	search_again=1 ;;
 
-		S)	is_get_subscriptions=1 ;;
+		S)	scrape="yt_subs" ;;
 
 		l) 	YTFZF_LOOP=1 ;;
 
@@ -857,12 +853,19 @@ check_if_url "${search_query:=$*}"
 #format the menu screen
 format_menu 
 
-[ "$is_get_subscriptions" -eq 1 ] && get_subscriptions
 
-if [ $scrape -eq 1 ]; then 
-	get_search_query
-	scrape_yt "$search_query"
-fi
+case "$scrape" in
+	"yt_search") 
+		get_search_query
+		scrape_yt "$search_query" ;;
+	"yt_subs")
+		scrape_subscriptions
+		;;
+	"history") 
+		get_history 
+		;;
+esac
+
 
 while true; do
 	user_selection

--- a/ytfzf
+++ b/ytfzf
@@ -12,8 +12,8 @@ YTFZF_VERSION="1.0.1"
 
 
 #>reading the config file
-config_dir="$HOME/.config/ytfzf"
-config_file="$config_dir/conf.sh"
+config_dir="${YTFZF_CONFIG_DIR-$HOME/.config/ytfzf}"
+config_file="${YTFZF_CONFIG_FILE-$config_dir/conf.sh}"
 tmp_video_data_file="/tmp/ytfzf-subdata"
 printf "" > "$tmp_video_data_file"
 #source config file if exists
@@ -126,78 +126,91 @@ dep_ck "jq" "youtube-dl";
 ############################
 #       Help Texts         #
 ############################
-helpinfo () {
-printf "Usage: %bytfzf [OPTIONS] %b<search-query>%b\n" "\033[1;32m" "\033[1;33m" "\033[0m";
-printf "  OPTIONS:\n"
-printf "     -h, --help                           Show this help text\n";
-printf "     -v, --version                        -v for ytfzf's version\n";
-printf "                                          --version for ytfzf + dependency's versions\n"
-printf "     -t, --thumbnails                     Show thumbnails (requires ueberzug)\n";
-printf "                                          Doesn't work with -H -D\n";
-printf "     -D, --ext-menu                       Use external menu(default dmenu) instead of fzf \n";
-printf "     -H, --choose-from-history            Choose from history \n";
-printf "     -x, --clear-history                  Delete history\n";
-printf "     -m, --audio-only   <search-query>    Audio only (for music)\n";
-printf "     -d, --download     <search-query>    Download to current directory\n";
-printf "     -f                 <search-query>    Show available formats before proceeding\n";
-printf "     -a, --auto-play    <search-query>    Auto play the first result, no selector\n";
-printf "     -r  --random-play  <search-query>    Auto play a random result, no selector\n";
-printf "     -A, --select-all   <search-query>    Selects all results\n";
-printf "     -n, --video-count= <video-count>     To specify number of videos to select with -a, -r\n";
-printf "     -l, --loop         <search-query>    Loop: prompt selector again after video ends\n";
-printf "     -s                 <search-query>    After the video ends make another search \n";
-printf "     -L, --link-only    <search-query>    Prints the selected URL only, helpful for scripting\n";
-printf "\n";
-printf "  Subscriptions: to add a channel to subscptions, copy the channel's video page url\n";
-printf "                 and add it to ~/.config/ytfzf/subscriptions. Each url must be on a new line\n";
-printf "     -S,  --subs                          Get the latest 10 videos from subscriptions\n"
-printf "     --subs=<number>                      Get the latest <number> of videos from subscriptions\n";
-printf "     --fancy-subs=                        whether or not to show ------channel------ in subscriptions (must be 1 or 0)\n";
-printf "\n"
-printf "     --previews=        <left/right>      the side of the screen to show thumbnails\n";
-printf "     --upload-time=     <time-range>      Time range can be one of, \n";
-printf "                                          last-hour, today, this-week, this-month, this-year\n"
-printf "                                          Filters can go directly: --today\n";
-printf "     --upload-sort=     <sort-filter>     The filter to sort the videos can be one of\n";
-printf "                                          upload-date, view-count, rating\n";
-printf "                                          Filters can go directly: --upload-date\n";
-printf "     --filter-id=       <filter>          The id of the filter to use for video results\n";
-printf "         A filter id can be found by going to Youtube searching, filtering how you want\n";
-printf "         Then taking the value of the &sp= part of the url\n";
-printf "         Filters may not work especially when the filter sorts for non-videos\n";
-printf "         In addition this overrides any filter provided through options\n";
-printf "         Example: \033[1mytfzf --filter-id=EgJAAQ minecraft\033[000m\n";
-printf "         This will filter by livestream\n";
-printf "\n";
-printf "     --update                             clones the latest stable commit and installs it\n";
-printf "                                          on Arch ytfzf is available in the AUR\n";
-printf "     --update-unstable                    gets the latest commit and installs it (--update is safer)\n";
-printf "\n";
-printf "  Use - instead of <search-query> for stdin\n";
-printf "\n"
-printf "  Option usage:\n"
-printf "     ytfzf -fDH                           to show history using external \n"
-printf "                                          menu and show formats\n"
-printf "     ytfzf -fD --choose-from-history      same as above\n"
-printf "\n"
-printf "  Defaults can be modified through ENV variables or the config file\n";
-printf "  the default config file can be found at https://github.com/pystardust/ytfzf/blob/master/docs/conf.sh\n";
-printf "  Defaults:\n";
-printf "     YTFZF_HIST=1                          0 : off history\n";
-printf "     YTFZF_CACHE=~/.cache/ytfzf\n";
-printf "     YTFZF_LOOP=0                          1 : loop the selection prompt\n";
-printf "     YTFZF_PREF=''                         22: 720p,  18: 360p\n";
-printf "     YTFZF_CUR=1                           For status bar bodules\n";
-printf "     YTFZF_EXTMENU=' dmenu -i -l 30'\n";
-printf "  To use rofi\n";
-printf "     YTFZF_EXTMENU=' rofi -dmenu -fuzzy -width 1500'\n";
-printf "     YTFZF_ENABLE_FZF_DEFAULT_OPTS=0       1 : fzf will use FZF_DEFAULT_OPTS\n";
-printf "\n";
+
+basic_helpinfo () {
+    printf "Usage: ytfzf [OPTIONS...] <search-query>\n";
+    printf "  OPTIONS:\n" 
+    printf "     -h, --help                             Show this help text\n";
+    printf "     -v, --version                          -v for ytfzf's version\n";
+    printf "                                            --version for ytfzf + dependency's versions\n"
+    printf "     -t, --thumbnails                       Show thumbnails (requires ueberzug)\n";
+    printf "                                            Doesn't work with -H -D\n";
+    printf "     -D, --ext-menu                         Use external menu(default dmenu) instead of fzf \n";
+    printf "     -H, --choose-from-history              Choose from history \n";
+    printf "     -x, --clear-history                    Delete history\n";
+    printf "     -m, --audio-only     <search-query>    Audio only (for music)\n";
+    printf "     -d, --download       <search-query>    Download to current directory\n";
+    printf "     -f                   <search-query>    Show available formats before proceeding\n";
+    printf "     -a, --auto-select    <search-query>    Auto play the first result, no selector\n";
+    printf "     -r  --random-select  <search-query>    Auto play a random result, no selector\n";
+    printf "     -A, --select-all     <search-query>    Selects all results\n";
+    printf "     -n, --link-count=    <link-count>      To specify number of videos to select with -a, -r\n";
+    printf "     -l, --loop           <search-query>    Loop: prompt selector again after video ends\n";
+    printf "     -s, --search-again   <search-query>    After the video ends make another search \n";
+    printf "     -L, --link-only      <search-query>    Prints the selected URL only, helpful for scripting\n";
+    printf "     --preview-side=      <left/right/top/bottom>    the side of the screen to show thumbnails\n";
+    printf "\n"
+    printf "  Use - instead of <search-query> for stdin\n" 
+    printf "\n";
+    printf "  Option usage:\n" 
+    printf "     ytfzf -fDH                           to show history using external \n"
+    printf "                                          menu and show formats\n"
+    printf "     ytfzf -fD --choose-from-history      same as above\n"
+    printf "\n"
 }
+
+all_help_info () {
+    basic_helpinfo
+    printf "  Subscriptions: to add a channel to subscptions, copy the channel's video page url\n" 
+    printf "                 and add it to ~/.config/ytfzf/subscriptions. Each url must be on a new line\n";
+    printf "     -S,  --subs                          Get the latest 10 videos from subscriptions\n"
+    printf "     --subs=<number>                      Get the latest <number> of videos from subscriptions\n";
+    printf "     --fancy-subs=                        whether or not to show ------channel------ in subscriptions (must be 1 or 0)\n";
+    printf "\n"
+    printf "  Filters: different ways to filter videos in search\n" 
+    printf "     --upload-time=     <time-range>      Time range can be one of, \n";
+    printf "                                          last-hour, today, this-week, this-month, this-year\n"
+    printf "                                          Filters can go directly: --today\n";
+    printf "     --upload-sort=     <sort-filter>     The filter to sort the videos can be one of\n";
+    printf "                                          upload-date, view-count, rating\n";
+    printf "                                          Filters can go directly: --upload-date\n";
+    printf "     --filter-id=       <filter>          The id of the filter to use for video results\n";
+    printf "         A filter id can be found by going to Youtube searching, filtering how you want\n";
+    printf "         Then taking the value of the &sp= part of the url\n";
+    printf "         Filters may not work especially when the filter sorts for non-videos\n";
+    printf "         In addition this overrides any filter provided through options\n";
+    printf "         Example: \033[1mytfzf --filter-id=EgJAAQ minecraft\033[0m\n";
+    printf "         This will filter by livestream\n";
+    printf "\n";
+    printf "  Update:\n" 
+    printf "     --update                             clones the latest stable commit and installs it\n";
+    printf "                                          on Arch ytfzf is available in the AUR\n";
+    printf "     --update-unstable                    gets the latest commit and installs it (--update is safer)\n";
+    printf "\n";
+    printf "\n"
+    printf "  Defaults can be modified through ENV variables or the config file\n";
+    printf "  the default config file can be found at https://github.com/pystardust/ytfzf/blob/master/docs/conf.sh%b\n"
+    printf "\n"
+    printf "  Environment Variables:\n" 
+    printf "     YTFZF_HIST=1                          0 : off history\n";
+    printf "     YTFZF_CACHE=~/.cache/ytfzf\n";
+    printf "     YTFZF_LOOP=0                          1 : loop the selection prompt\n";
+    printf "     YTFZF_PREF=''                         22: 720p,  18: 360p\n";
+    printf "     YTFZF_CUR=1                           For status bar bodules\n";
+    printf "     YTFZF_ENABLE_FZF_DEFAULT_OPTS=0       1 : fzf will use FZF_DEFAULT_OPTS\n";
+    printf "     YTFZF_CONFIG_DIR='~/.config/ytfzf'    The directory to store config files\n";
+    printf "     YTFZF_CONFIG_FILE='\$YTFZF_CONFIG_DIR/conf.sh'   The configuration file\n";
+    printf "     YTFZF_EXTMENU=' dmenu -i -l 30'\n";
+    printf "  To use rofi\n";
+    printf "     YTFZF_EXTMENU=' rofi -dmenu -fuzzy -width 1500'\n";
+    printf "\n";
+}
+
 usageinfo () {
     printf "Usage: %bytfzf %b<search query>%b\n" "\033[1;32m" "\033[1;33m" "\033[0m";
     printf "     'ytfzf -h' for more information\n";
 }
+
 print_error () {
     printf "$*"
     printf "Check for new versions and report at: https://github.com/pystardust/ytfzf\n"
@@ -395,7 +408,7 @@ download_thumbnails () {
 		else
 			name="$line"
 			{
-				curl -s "$url" > "$thumb_dir/$name.png"
+			    curl -s "$url" > "$thumb_dir/$name.png"
 			} &
 		fi
 		i=$((i + 1))
@@ -486,7 +499,7 @@ scrape_channel () {
 	yt_html="$(get_yt_html "$*")"
 
 	if [ -z "$yt_html" ]; then
-	        print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
+	        print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[0m\n"
 	        exit 1
 	fi
 
@@ -548,7 +561,7 @@ scrape_yt () {
 
 	yt_html="$(get_yt_html "https://www.youtube.com/results" "$*")"
 	if [ -z "$yt_html" ]; then
-		print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
+		print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[0m\n"
 		exit 1
 	fi
 
@@ -556,7 +569,7 @@ scrape_yt () {
 
 	#if the data couldn't be found
 	if [ -z "$yt_json" ]; then
-		print_error "\033[31mERROR[#02]: Couldn't find data on site.\033[000m\n"
+		print_error "\033[31mERROR[#02]: Couldn't find data on site.\033[0m\n"
 		exit 1
 	fi
 
@@ -680,7 +693,7 @@ play_url () {
 		[ 4 -eq $? ] || eval "$YTFZF_PLAYER" "$player_urls"
                      # Ctr-C in MPV results in a return code of 4
 	} || {
-		print_error "\033[31mERROR[#03]: Couldn't play the video/audio using the current player: ${YTFZF_PLAYER}\n\t\033[000mTry updating youtube-dl\n"; save_before_exit ; exit 1;
+		print_error "\033[31mERROR[#03]: Couldn't play the video/audio using the current player: ${YTFZF_PLAYER}\n\t\033[0mTry updating youtube-dl\n"; save_before_exit ; exit 1;
 	}
 }
 #> Checks if other sessions are running, if not then deletes thumbnails
@@ -737,7 +750,7 @@ clear_history () {
 		echo "" > "$history_file"
 		printf "History has been cleared\n"
 	else
-		printf "\033[31mHistory file not found, history not cleared\033[000m\n"
+		printf "\033[31mHistory file not found, history not cleared\033[0m\n"
 		exit 1
 	fi
 }
@@ -788,7 +801,7 @@ is_non_number () {
 bad_opt_arg () {
 	opt="$1"
 	arg="$2"
-	printf "%s\n" "$opt requires a numeric arg, but was given \"$OPTARG\""
+	printf "%s\n" "$opt requires a numeric arg, but was given \"$arg\""
 	exit 2
 }
 
@@ -798,9 +811,12 @@ parse_long_opt () {
 	#if the option has a short version it calls this function with the opt as the shortopt
 	case "${opt}" in
 	        help) parse_opt "h" ;;
+		help-all) 
+		    all_help_info 
+		    exit ;;
 
-		ext-menu) parse_opt "D" ;;
-		ext-menu=*)
+		is-ext-menu) parse_opt "D" ;;
+		is-ext-menu=*)
 		    parse_opt "D" "${opt#*=}"
 		    is_non_number "$is_ext_menu" && bad_opt_arg "--ext-menu=" "$is_ext_menu" ;;
 
@@ -810,8 +826,8 @@ parse_long_opt () {
 
 		clear-history) parse_opt "x" ;;
 
-		search) parse_opt "s" ;;
-		search=*)
+		search-again) parse_opt "s" ;;
+		search-again=*) 
 		    parse_opt "s" "${opt#*=}"
 		    is_non_number "$search_again" && bad_opt_arg "--search=" "$search_again" ;;
 
@@ -820,22 +836,22 @@ parse_long_opt () {
 		    parse_opt "l" "${opt#*=}"
 		    is_non_number "$YTFZF_LOOP" && bad_opt_arg "--loop=" "$YTFZF_LOOP" ;;
 
-		thumbnails) parse_opt "t" ;;
-		thumbnails=*)
+		show-thumbnails) parse_opt "t" ;;
+		show-thumbnails=*)
 		    parse_opt "t" "${opt#*=}"
 		    is_non_number "$show_thumbnails" && bad_opt_arg "--thumbnails=" "$show_thumbnails" ;;
 
-		link-only) parse_opt "L" ;;
-		link-only=*)
+		show-link-only) parse_opt "L" ;;
+		show-link-only=*)
 		    parse_opt "L" "${opt#*=}"
 		    is_non_number "$show_link_only" && bad_opt_arg "--link-only=" "$show_link_only" ;;
 
-		video-count=*) parse_opt "n" "${opt#*=}" ;;
+		link-count=*) parse_opt "n" "${opt#*=}" ;;
 
 		audio-only) parse_opt "m" ;;
 
-		auto-play) parse_opt "a" ;;
-		auto-play=*)
+		auto-select) parse_opt "a" ;;
+		auto-select=*) 
 		    parse_opt "a" "${opt#*=}"
 		    is_non_number "$auto_select" && bad_opt_arg "--auto-play=" "$auto_select" ;;
 
@@ -844,8 +860,8 @@ parse_long_opt () {
 		    parse_opt "A" "${opt#*=}"
 		    is_non_number "$select_all" && bad_opt_arg "--select-all=" "$select_all" ;;
 
-		random-play) parse_opt "r" ;;
-		random-play=*)
+		random-select) parse_opt "r" ;;
+		random-select=*) 
 		    parse_opt "r" "${opt#*=}"
 		    is_non_number "$random_select" && bad_opt_arg "--random-play=" "$random_select" ;;
 
@@ -863,7 +879,7 @@ parse_long_opt () {
 
 		filter-id=*|sp=*) sp="${opt#*=}" ;;
 
-		previews=*) export PREVIEW_SIDE="${opt#*=}" ;;
+		preview-side=*) export PREVIEW_SIDE="${opt#*=}" ;;
 
 		update) update_ytfzf "master" ;;
 		update-unstable) update_ytfzf "development" ;;
@@ -879,9 +895,9 @@ parse_long_opt () {
 		fancy-subs=*) fancy_subscriptions_menu="${opt#*=}" ;;
 
 		version)
-		    printf "\033[1mytfzf:\033[000m %s\n" "$YTFZF_VERSION"
-		    printf "\033[1myoutube-dl:\033[00m %s\n" "$(youtube-dl --version)"
-		    command -v "fzf" 1>/dev/null && printf "\033[1mfzf:\033[000m %s\n" "$(fzf --version)"
+		    printf "\033[1mytfzf:\033[0m %s\n" "$YTFZF_VERSION"
+		    printf "\033[1myoutube-dl:\033[0m %s\n" "$(youtube-dl --version)"
+		    command -v "fzf" 1>/dev/null && printf "\033[1mfzf:\033[0m %s\n" "$(fzf --version)"
 		    exit ;;
 
 		*)
@@ -899,7 +915,8 @@ parse_opt () {
 		#Long options
 		-)	parse_long_opt "$OPTARG" ;;
 		#Short options
-		h) 	helpinfo
+		h) 	basic_helpinfo
+			printf "type --help-all for more info\n"
 			exit ;;
 
 		D) 	is_ext_menu="${OPTARG:-1}" ;;
@@ -957,14 +974,14 @@ shift $((OPTIND-1))
 #if both are true, it defaults to using fzf, and if fzf isnt installed it will throw an error
 #so print this error instead and set $show_thumbnails to 0
 if [ $is_ext_menu -eq 1 -a $show_thumbnails -eq 1 ]; then
-	printf "\033[31mCurrently thumbnails do not work in external menus\033[000m\n"
+	printf "\033[31mCurrently thumbnails do not work in external menus\033[0m\n"
 	show_thumbnails=0
 fi
 
 #if stdin is given and no input (including -) is given, throw error
 #also make sure its not reading from ext_menu
 if [ ! -t 0 ] && [ -z "$*" ] && [ $is_ext_menu -eq 0 ]; then
-	printf "\033[31mERROR[#04]: Use - when reading from stdin\033[000m\n"
+	print_error "\033[31mERROR[#04]: Use - when reading from stdin\033[0m\n"
 	exit 2
 #read stdin if given
 elif [ "$*" = "-" ]; then

--- a/ytfzf
+++ b/ytfzf
@@ -512,14 +512,14 @@ user_selection () {
 	selected_data=""
 	while read surl; do
 		[ -z "$surl" ] && continue
-		urls="$urls\nhttps://www.youtube.com/watch?v=$surl"
+		urls="${urls}$(printf '\n')https://www.youtube.com/watch?v=$surl"
 		selected_data="$selected_data\n$(echo "$videos_data" | grep -m1 -e "$surl" )"
 	done << EOF
 	$shorturls
 EOF
-	urls="$( printf "$urls" | sed 1d )"
+	urls="$( printf "%s" "$urls" | sed 1d )"
 	#sometimes % shows up in selected data, could throw an error if it's an invalid directive
-	selected_data="$( printf "$selected_data" | sed 1d )"
+	selected_data="$( printf "%s" "$selected_data" | sed 1d )"
 
 	if [ $show_link_only -eq 1 ] ; then
 		echo "$urls"

--- a/ytfzf
+++ b/ytfzf
@@ -54,13 +54,12 @@ printf "" > "$tmp_video_data_file"
 #> files and directories
 history_file="${history_file-$YTFZF_CACHE/ytfzf_hst}"
 current_file="${current_file-$YTFZF_CACHE/ytfzf_cur}"
-thumb_dir="$YTFZF_CACHE/thumb"
+thumb_dir="${thumb_dir-$YTFZF_CACHE/thumb}"
 #> Stores urls of the video page of channels
 subscriptions_file="${subscriptions_file-$config_dir/subscriptions}"
 
 #> stores the pid of running ytfzf sessions
 pid_file="$YTFZF_CACHE/.pid"
-thumb_dir="$YTFZF_CACHE/thumb"
 #> make folders that don't exist
 [ -d "$YTFZF_CACHE" ] || mkdir -p "$YTFZF_CACHE"
 [ -d "$thumb_dir" ] || mkdir -p "$thumb_dir"

--- a/ytfzf
+++ b/ytfzf
@@ -455,7 +455,15 @@ scrape_channel () {
 	fi
 
 	#gets the channel name from title of page
-	channel_name="$(echo "$yt_html" | grep -o '<title>.*</title>' | sed 's/<\/\?title>//g' | sed 's/ - YouTube//')"
+	channel_name="$(echo "$yt_html" | grep -o '<title>.*</title>' | sed 's/<\/\?title>//g' | sed 's/ - YouTube//' |\
+		sed \
+		-e "s/&apos;/'/g" \
+		-e "s/&#39;/'/g" \
+		-e "s/&quot;/\"/g" \
+		-e "s/&#34;/\"/g" \
+		-e "s/&amp;/\&/g" \
+		-e "s/&#38;/\&/g" 
+		)"
 
 	#gets json of videos
 	yt_json="$(get_yt_json "$yt_html")"

--- a/ytfzf
+++ b/ytfzf
@@ -424,14 +424,14 @@ get_sp_filter () {
 
 get_yt_json () {
 	#youtube has a bunch of data relating to videos in a json format, this scrapes that
-	yt_json="$(printf "%s" "$*" | sed -n '/var *ytInitialData/,$p' | tr -d '\n' |\
-        sed -E ' s_^.*var ytInitialData ?=__ ; s_;</script>.*__ ;')"
+	printf "%s" "$*" | sed -n '/var *ytInitialData/,$p' | tr -d '\n' |\
+        sed -E ' s_^.*var ytInitialData ?=__ ; s_;</script>.*__ ;'
 }
 
 get_yt_html () {
     link="$1"
     query="$2"
-    yt_html="$(
+    printf "%s" "$(
 	curl "$link" -s \
 	  -G --data-urlencode "search_query=$query" \
 	  -G --data-urlencode "sp=$sp" \
@@ -448,7 +448,7 @@ get_yt_html () {
 
 get_video_data () {
 	#in that list this finds the title, channel, view count, video length, video upload date, and the video id/url
-	videos_data="$(printf "%s" "$*" |\
+	printf "%s" "$*" |\
 		jq -r '.[]| (
 			.title,
 			.channel,
@@ -456,19 +456,19 @@ get_video_data () {
 			.duration,
 			.date,
 			.videoID
-			)' | sed "N;N;N;N;N;s/\n/""$(printf '\t')""\|/g")"
-	    #if there aren't videos
-	    [ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
+			)' | sed "N;N;N;N;N;s/\n/""$(printf '\t')""\|/g"
+	#if there aren't videos
+	[ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
 }
 
 scrape_subscriptions () {
 	for link in $*; do
 	    echo "Fetching $link" 
-	    get_yt_html "$link"
+	    yt_html="$(get_yt_html "$link")"
 	    #gets the channel name from title of page
 	    channel_name="$(echo "$yt_html" | grep -o '<title>.*</title>' | sed 's/<\/\?title>//g' | sed 's/ - YouTube//')"
 	    #gets json of videos
-	    get_yt_json "$yt_html"
+	    yt_json="$(get_yt_json "$yt_html")"
 	    #gets a list of videos
 	    videos_json="$(printf "%s" "$yt_json" |\
 	    jq '[ .contents | ..|.gridVideoRenderer? | 
@@ -489,7 +489,7 @@ scrape_subscriptions () {
 
 	    temp_videos_data="$videos_data"
 
-	    get_video_data "$videos_json"
+	    videos_data="$(get_video_data "$videos_json")"
 
 	    #if not select all, or random select, get only the needed videos
 	    if [ $select_all -eq 0 -a $random_select -eq 0 ]; then
@@ -524,9 +524,9 @@ scrape_yt () {
 		sp="${sp%%%*}"
 	fi
 
-	get_yt_html "https://www.youtube.com/results" "$*"
+	yt_html="$(get_yt_html "https://www.youtube.com/results" "$*")"
 
-	get_yt_json "$yt_html"
+	yt_json="$(get_yt_json "$yt_html")"
 
 	#if the data couldn't be found
 	if [ -z "$yt_json" ]; then  
@@ -549,7 +549,7 @@ scrape_yt () {
 		}
 	]')"
 
-	get_video_data "$videos_json"
+	videos_data="$(get_video_data "$videos_json")"
 
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$(printf "%s" "$videos_json" | jq  -r '.[]|(.thumbs,.videoID)' )"
 }

--- a/ytfzf
+++ b/ytfzf
@@ -364,7 +364,8 @@ download_thumbnails () {
 	i=0
 	while read -r line; do
 		if [ $((i % 2)) -eq 0 ]; then
-			url="$(echo "$line" | sed -E 's/^"//;s/\.png.*/\.png/')" 
+			url="$line" 
+			sleep 0.002
 		else
 			name="$line"
 			{ 

--- a/ytfzf
+++ b/ytfzf
@@ -467,8 +467,7 @@ scrape_channel () {
 	    }
 	]')"
 	
-	videos_data="$(printf "\n%s\n%s\n" "--------------------${channel_name}------------------------------------------------------" \
-		"$(get_video_data "$videos_json")" )"
+	videos_data="$(get_video_data "$videos_json")"
 	
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Make sure the link is correct.\n"; exit 1;}

--- a/ytfzf
+++ b/ytfzf
@@ -87,6 +87,8 @@ show_link_only=${show_link_only-0}
 show_format=${show_format-0}
 #number of links to select with -a or -r (same as -n)
 link_count=${link_count-1}
+#number of videos to show in the subsciption menu
+sub_link_count=${sub_link_count-10}
 #after video ends, make another search (same as -s)
 search_again=${search_again-0}
 #filter id used when searching
@@ -473,11 +475,12 @@ scrape_channel () {
 	    }
 	]')"
 	
+	videos_json="$(echo "$videos_json" | jq '.[0:'$sub_link_count']')"
 	videos_data="$(get_video_data "$videos_json")"
-	
+
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Make sure the link is correct.\n"; exit 1;}
-	printf "             -------%s-------\t---\t---\t---\n%s\n" "$channel_name" \
+	printf "             -------%s-------\n%s\n" "$channel_name" \
 		"$videos_data" >> "$tmp_video_data_file"
 	
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
@@ -823,7 +826,9 @@ parse_opt () {
 
 		L) 	show_link_only=1 ;;
 
-		n)	link_count="$OPTARG" ;;
+		n)	link_count="$OPTARG" 
+			sub_link_count="$OPTARG"
+			;;
 
 		U) 	[ -p "$FIFO" ] && preview_img "$OPTARG"; exit;
 			# This option is reserved for the script, to show image previews

--- a/ytfzf
+++ b/ytfzf
@@ -14,6 +14,8 @@ YTFZF_VERSION="1.0.1"
 #>reading the config file 
 config_dir="$HOME/.config/ytfzf"
 config_file="$config_dir/conf.sh"
+tmp_video_data_file="/tmp/ytfzf-subdata"
+printf "" > "$tmp_video_data_file"
 #source config file if exists
 [ -e "$config_file" ] && . "$config_file"
 
@@ -88,9 +90,8 @@ link_count=${link_count-1}
 search_again=${search_again-0}
 #filter id used when searching
 sp="${sp-}"
-#scrape subscriptions file instead of a search query
-get_subscriptions=0
-
+# Gets subscriptions from sub file if 1
+is_get_subscriptions=0
 #ueberzug related variables
 #the side where thumbnails are shown
 #needs to be exported because ueberzug spawns subprocesses
@@ -344,9 +345,6 @@ download_thumbnails () {
        #scrapes the urls of the thumbnails of the videos from the adjusted json
        thumb_urls="$(printf "%s" "$*" |\
                jq  -r '.[]|(.thumbs,.videoID)' )"
-
-	[ "$show_link_only" -eq 0 ] && printf "Downloading Thumbnails"
-    
 	i=0
 	while read -r line; do
 		if [ $((i % 2)) -eq 0 ]; then
@@ -474,6 +472,7 @@ scrape_channel () {
 	
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Make sure the link is correct.\n"; exit 1;}
+	printf "%s" "$videos_data\n" >> "$tmp_video_data_file"
 	
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 }
@@ -523,6 +522,7 @@ scrape_yt () {
 	videos_data="$(get_video_data "$videos_json")"
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
+	printf "%s" "$videos_data\n" >> "$tmp_video_data_file"
 
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 }
@@ -567,7 +567,7 @@ user_selection () {
 		menu_command="fzf -m --tabstop=1 --bind change:top --delimiter=\"$(printf \"\t\")\" --nth=1,2 $FZF_DEFAULT_OPTS \
 		--layout=reverse --preview \"sh $0 -U {}\" \
         	--preview-window \"$PREVIEW_SIDE:50%:noborder:wrap\""
-		selected_data="$( video_menu "$videos_data" )"
+		selected_data="$( title_len=200 video_menu "$videos_data" )"
 		stop_ueberzug 
 		# Deletes thumbnails if no video is selected
 		[ -z "$selected_data" ] && delete_thumbnails 
@@ -697,6 +697,15 @@ update_ytfzf () {
 	exit
 }
 
+get_subscriptions () {
+	scrape=0
+	while read -r url; do
+		 scrape_channel "$url"  &
+	done < "$subscriptions_file"
+	wait
+	videos_data="$(cat "$tmp_video_data_file")"
+}
+
 #is used to know whether or not scraping the search page is necessary
 scrape=1
 #OPT
@@ -798,7 +807,7 @@ parse_opt () {
 
 		s)	search_again=1 ;;
 
-		S)	get_subscriptions=1 ;;
+		S)	is_get_subscriptions=1 ;;
 
 		l) 	YTFZF_LOOP=1 ;;
 
@@ -841,17 +850,19 @@ elif [ "$*" = "-" ]; then
 	done
 fi
 check_if_url "${search_query:=$*}" 
+
 # If in auto select mode dont download thumbnails
 [ $auto_select -eq 1 ] || [ $random_select -eq 1 ] && show_thumbnails=0; 
 
 #format the menu screen
 format_menu 
 
+[ "$is_get_subscriptions" -eq 1 ] && get_subscriptions
+
 if [ $scrape -eq 1 ]; then 
 	get_search_query
 	scrape_yt "$search_query"
 fi
-#scrape_channel "https://www.youtube.com/user/PewDiePie/videos"
 
 while true; do
 	user_selection

--- a/ytfzf
+++ b/ytfzf
@@ -440,10 +440,6 @@ get_yt_html () {
 	  -H 'accept-language: en-US,en;q=0.9' \
 	  --compressed
     )"
-    if [ -z "$yt_html" ]; then
-	    print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
-	    exit 1 
-    fi
 }
 
 get_video_data () {
@@ -457,14 +453,16 @@ get_video_data () {
 			.date,
 			.videoID
 			)' | sed "N;N;N;N;N;s/\n/""$(printf '\t')""\|/g"
-	#if there aren't videos
-	[ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
 }
 
 scrape_subscriptions () {
 	for link in $*; do
 	    echo "Fetching $link" 
 	    yt_html="$(get_yt_html "$link")"
+	    if [ -z "$yt_html" ]; then
+		    print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
+		    exit 1 
+	    fi
 	    #gets the channel name from title of page
 	    channel_name="$(echo "$yt_html" | grep -o '<title>.*</title>' | sed 's/<\/\?title>//g' | sed 's/ - YouTube//')"
 	    #gets json of videos
@@ -490,6 +488,8 @@ scrape_subscriptions () {
 	    temp_videos_data="$videos_data"
 
 	    videos_data="$(get_video_data "$videos_json")"
+	    #if there aren't videos
+	    [ -z "$videos_data" ] &&  { printf "No results found. Make sure the link is correct.\n"; exit 1;}
 
 	    #if not select all, or random select, get only the needed videos
 	    if [ $select_all -eq 0 -a $random_select -eq 0 ]; then
@@ -525,6 +525,10 @@ scrape_yt () {
 	fi
 
 	yt_html="$(get_yt_html "https://www.youtube.com/results" "$*")"
+	if [ -z "$yt_html" ]; then
+		print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
+		exit 1 
+	fi
 
 	yt_json="$(get_yt_json "$yt_html")"
 
@@ -550,6 +554,8 @@ scrape_yt () {
 	]')"
 
 	videos_data="$(get_video_data "$videos_json")"
+	#if there aren't videos
+	[ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
 
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$(printf "%s" "$videos_json" | jq  -r '.[]|(.thumbs,.videoID)' )"
 }

--- a/ytfzf
+++ b/ytfzf
@@ -133,19 +133,22 @@ printf "                                          Doesn't work with -H -D\n";
 printf "     -D, --ext-menu                       Use external menu(default dmenu) instead of fzf \n";
 printf "     -H, --choose-from-history            Choose from history \n";
 printf "     -x, --clear-history                  Delete history\n";
-printf "     -S                                   Get the latest videos from subscriptions\n"
 printf "     -m, --audio-only   <search-query>    Audio only (for music)\n";
 printf "     -d, --download     <search-query>    Download to current directory\n";
 printf "     -f                 <search-query>    Show available formats before proceeding\n";
 printf "     -a, --auto-play    <search-query>    Auto play the first result, no selector\n";
 printf "     -r  --random-play  <search-query>    Auto play a random result, no selector\n";
 printf "     -A, --select-all   <search-query>    Selects all results\n";
-printf "     -n, --video-count= <video-count>     To specify number of videos to select with -a, -r or -S\n";
-printf "                   if -n is given with both -a/-r and -S, it will apply to both"
+printf "     -n, --video-count= <video-count>     To specify number of videos to select with -a, -r\n";
 printf "     -l, --loop         <search-query>    Loop: prompt selector again after video ends\n";
 printf "     -s                 <search-query>    After the video ends make another search \n";
 printf "     -L, --link-only    <search-query>    Prints the selected URL only, helpful for scripting\n";
 printf "\n";
+printf "  Subscriptions: to add a channel to subscptions, copy the channel's video page url\n";
+printf "                 and add it to ~/.config/ytfzf/subscriptions. Each url must be on a new line\n";
+printf "     -S,  --subs                          Get the latest 10 videos from subscriptions\n"
+printf "     --subs=<number>                      Get the latest <number> of videos from subscriptions\n"
+printf "\n"
 printf "     --previews=        <left/right>      the side of the screen to show thumbnails\n";
 printf "     --upload-time=     <time-range>      Time range can be one of, \n";
 printf "                                          last-hour, today, this-week, this-month, this-year\n"

--- a/ytfzf
+++ b/ytfzf
@@ -519,7 +519,7 @@ user_selection () {
 EOF
 	urls="$( printf "$urls" | sed 1d )"
 	#sometimes % shows up in selected data, could throw an error if it's an invalid directive
-	selected_data="$( printf "%s" "$selected_data" | sed 1d )"
+	selected_data="$( printf "$selected_data" | sed 1d )"
 
 	if [ $show_link_only -eq 1 ] ; then
 		echo "$urls"

--- a/ytfzf
+++ b/ytfzf
@@ -512,8 +512,8 @@ user_selection () {
 	selected_data=""
 	while read surl; do
 		[ -z "$surl" ] && continue
-		urls="${urls}$(printf '\n')https://www.youtube.com/watch?v=$surl"
-		selected_data="$selected_data\n$(echo "$videos_data" | grep -m1 -e "$surl" )"
+		urls="$(printf '%s\n%s' "${urls}" "https://www.youtube.com/watch?v=$surl")"
+		selected_data="$(printf '%s\n%s' "$selected_data" "$(echo "$videos_data" | grep -m1 -e "$surl" )")"
 	done << EOF
 	$shorturls
 EOF

--- a/ytfzf
+++ b/ytfzf
@@ -303,11 +303,17 @@ stop_ueberzug () {
 }
 
 preview_img () {
-       shorturl="$(echo "$*" | sed -E -e 's_^.*\|__')"
+	shorturl="$( printf "%s" "$*" | sed -E -n -e 's_^.*\|([^|]+) *_\1_p')"
 
-       thumb_width=$WIDTH
-       thumb_height=$((HEIGHT - 2))
-       #most common x, y positions
+       if [ -z "$shorturl" ] ; then
+	       printf '{ "action": "remove", "identifier": "%s" }\n' "$ID" > "$FIFO"
+	       return
+	fi
+
+
+	thumb_width=$WIDTH
+	thumb_height=$((HEIGHT - 2))
+	#most common x, y positions
 
 	thumb_x=$((TTY_COLS / 2 + 3))
 	thumb_y=10
@@ -437,6 +443,8 @@ get_video_data () {
 }
 
 scrape_channel () {
+	# needs channel url as $*
+	## Scrape data and store video information in videos_data ( and thumbnails )
 	yt_html="$(get_yt_html "$*")"
 	
 	if [ -z "$yt_html" ]; then
@@ -469,14 +477,14 @@ scrape_channel () {
 	
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Make sure the link is correct.\n"; exit 1;}
-	printf "%s" "$videos_data" >> "$tmp_video_data_file"
+	printf "             -------%s-------\t---\t---\t---\n%s\n" "$channel_name" \
+		"$videos_data" >> "$tmp_video_data_file"
 	
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 }
 scrape_yt () {
-	# needs search_query
-	## Scrape data and store video information in videos_data ( and thumbnails download)
-	## GETTING DATA
+	# needs search_query as $*
+	## Scrape data and store video information in videos_data ( and thumbnails )
 
 	#sp is the urlquery youtube uses for sorting videos
 	#only runs if --filter-id or --sp was unspecified
@@ -519,7 +527,7 @@ scrape_yt () {
 	videos_data="$(get_video_data "$videos_json")"
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
-	printf "%s" "$videos_data\n" >> "$tmp_video_data_file"
+	printf "%s\n" "$videos_data" >> "$tmp_video_data_file"
 
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 	wait
@@ -595,6 +603,7 @@ EOF
 
 	if [ "$show_link_only" -eq 1 ] ; then
 		echo "$urls"
+		exit
 	fi
 
 	# select format if flag given
@@ -869,7 +878,6 @@ esac
 
 while true; do
 	user_selection
-	[ $show_link_only -eq 1 ] && exit
 	play_url
 	save_before_exit
 	

--- a/ytfzf
+++ b/ytfzf
@@ -52,8 +52,8 @@ printf "" > "$tmp_video_data_file"
 [ "$YTFZF_ENABLE_FZF_DEFAULT_OPTS" -eq 0 ] && FZF_DEFAULT_OPTS=""
 
 #> files and directories
-history_file="$YTFZF_CACHE/ytfzf_hst"
-current_file="$YTFZF_CACHE/ytfzf_cur"
+history_file="${history_file-$YTFZF_CACHE/ytfzf_hst}"
+current_file="${current_file-$YTFZF_CACHE/ytfzf_cur}"
 thumb_dir="$YTFZF_CACHE/thumb"
 #> Stores urls of the video page of channels
 subscriptions_file="${subscriptions_file-$config_dir/subscriptions}"
@@ -91,8 +91,13 @@ link_count=${link_count-1}
 sub_link_count=${sub_link_count-10}
 #after video ends, make another search (same as -s)
 search_again=${search_again-0}
+#whether or not to show -----------channel------------ when looking at subscriptions
+fancy_subscriptions_menu=${fancy_subscriptions_menu-1}
 #filter id used when searching
 sp="${sp-}"
+#is used to know whether or not scraping the search page is necessary
+scrape="${scrape-yt_search}"
+
 #ueberzug related variables
 #the side where thumbnails are shown
 #needs to be exported because ueberzug spawns subprocesses
@@ -147,7 +152,8 @@ printf "\n";
 printf "  Subscriptions: to add a channel to subscptions, copy the channel's video page url\n";
 printf "                 and add it to ~/.config/ytfzf/subscriptions. Each url must be on a new line\n";
 printf "     -S,  --subs                          Get the latest 10 videos from subscriptions\n"
-printf "     --subs=<number>                      Get the latest <number> of videos from subscriptions\n"
+printf "     --subs=<number>                      Get the latest <number> of videos from subscriptions\n";
+printf "     --fancy-subs=                        whether or not to show ------channel------ in subscriptions (must be 1 or 0)\n";
 printf "\n"
 printf "     --previews=        <left/right>      the side of the screen to show thumbnails\n";
 printf "     --upload-time=     <time-range>      Time range can be one of, \n";
@@ -491,8 +497,12 @@ scrape_channel () {
 
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Make sure the link is correct.\n"; exit 1;}
-	printf "             -------%s-------\t\n%s\n" "$channel_name" \
-		"$videos_data" >> "$tmp_video_data_file"
+	if [ "$fancy_subscriptions_menu" -eq 1 ]; then
+		printf "             -------%s-------\t\n%s\n" "$channel_name" \
+			"$videos_data" >> "$tmp_video_data_file"
+	else
+		printf "%s\n" "$videos_data" >> "$tmp_video_data_file"
+	fi
 	
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 }
@@ -739,8 +749,6 @@ bad_opt_arg () {
 	exit 2
 }
 
-#is used to know whether or not scraping the search page is necessary
-scrape="yt_search"
 #OPT
 parse_long_opt () {
 	opt="$1"
@@ -804,6 +812,9 @@ parse_long_opt () {
 			fi
 			parse_opt "S"
 			;;
+
+		fancy-subs) fancy_subscriptions_menu=1 ;;
+		fancy-subs=*) fancy_subscriptions_menu="${opt#*=}" ;;
 
 		version) 
 		    printf "\033[1mytfzf:\033[000m %s\n" "$YTFZF_VERSION"
@@ -882,7 +893,7 @@ while getopts "LhDmdfxHaArltSsvn:U:-:" opt; do
 done
 shift $((OPTIND-1))
 
-#if both are true, it defaults to using fzf, and if fzf isn't installed it will throw an error
+#if both are true, it defaults to using fzf, and if fzf isnt installed it will throw an error
 #so print this error instead and set $show_thumbnails to 0
 if [ $is_ext_menu -eq 1 -a $show_thumbnails -eq 1 ]; then
 	printf "\033[31mCurrently thumbnails do not work in external menus\033[000m\n"
@@ -890,7 +901,7 @@ if [ $is_ext_menu -eq 1 -a $show_thumbnails -eq 1 ]; then
 fi
 
 #if stdin is given and no input (including -) is given, throw error
-#also make sure it's not reading from ext_menu
+#also make sure its not reading from ext_menu
 if [ ! -t 0 ] && [ -z "$*" ] && [ $is_ext_menu -eq 0 ]; then
 	printf "\033[31mERROR[#04]: Use - when reading from stdin\033[000m\n"
 	exit 2

--- a/ytfzf
+++ b/ytfzf
@@ -53,6 +53,7 @@ config_file="$config_dir/conf.sh"
 history_file="$YTFZF_CACHE/ytfzf_hst"
 current_file="$YTFZF_CACHE/ytfzf_cur"
 thumb_dir="$YTFZF_CACHE/thumb"
+subscriptions_file="${subscriptions_file-$config_dir/subscriptions.json}"
 
 #> stores the pid of running ytfzf sessions
 pid_file="$YTFZF_CACHE/.pid"
@@ -65,6 +66,8 @@ thumb_dir="$YTFZF_CACHE/thumb"
 search_prompt="${search_prompt-Search Youtube: }"
 #used when getting the html from youtube
 useragent=${useragent-'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36'}
+#instead of just a list of videos, add some titles
+fancy_subscriptions_menu=${fancy_subscriptions_menu-1}
 
 #Opt variables (can also be set in config)
 #use $YTFZF_EXT_MENU (same as -D)
@@ -87,6 +90,8 @@ link_count=${link_count-1}
 search_again=${search_again-0}
 #filter id used when searching
 sp="${sp-}"
+#scrape subscriptions.json file instead of a search query
+get_subscriptions=0
 
 #ueberzug related variables
 #the side where thumbnails are shown
@@ -127,13 +132,15 @@ printf "                                          Doesn't work with -H -D\n";
 printf "     -D, --ext-menu                       Use external menu(default dmenu) instead of fzf \n";
 printf "     -H, --choose-from-history            Choose from history \n";
 printf "     -x, --clear-history                  Delete history\n";
+printf "     -S                                   Get the latest videos from subscriptions\n"
 printf "     -m, --audio-only   <search-query>    Audio only (for music)\n";
 printf "     -d, --download     <search-query>    Download to current directory\n";
 printf "     -f                 <search-query>    Show available formats before proceeding\n";
 printf "     -a, --auto-play    <search-query>    Auto play the first result, no selector\n";
 printf "     -r  --random-play  <search-query>    Auto play a random result, no selector\n";
 printf "     -A, --select-all   <search-query>    Selects all results\n";
-printf "     -n, --video-count= <video-count>     To specify number of videos to select with -a or -r\n";
+printf "     -n, --video-count= <video-count>     To specify number of videos to select with -a, -r or -S\n";
+printf "                   if -n is given with both -a/-r and -S, it will apply to both"
 printf "     -l, --loop         <search-query>    Loop: prompt selector again after video ends\n";
 printf "     -s                 <search-query>    After the video ends make another search \n";
 printf "     -L, --link-only    <search-query>    Prints the selected URL only, helpful for scripting\n";
@@ -343,7 +350,7 @@ preview_img () {
 
 download_thumbnails () {
 	#scrapes the urls of the thumbnails of the videos
-	thumb_urls="$(printf "%s" "$videos_json" |\
+	[ -z "$1" ] && thumb_urls="$(printf "%s" "$videos_json" |\
 		jq  -r '.[]|(.thumbs,.videoID)' )"
 
 	[ $show_link_only -eq 0 ] && printf "Downloading Thumbnails"
@@ -352,7 +359,6 @@ download_thumbnails () {
 	while read line; do
 		if [ $((i % 2)) -eq 0 ]; then
 			url="$(echo $line | sed -E 's/^"//;s/\.png.*/\.png/')" 
-			echo "$line \n $url"
 		else
 			name="$line"
 			{ 
@@ -409,6 +415,98 @@ get_sp_filter () {
 		sp="$filter_id"
 	fi
 }
+
+get_yt_json () {
+	#youtube has a bunch of data relating to videos in a json format, this scrapes that
+	yt_json="$(printf "%s" "$yt_html" | sed -n '/var *ytInitialData/,$p' | tr -d '\n' |\
+        sed -E ' s_^.*var ytInitialData ?=__ ; s_;</script>.*__ ;')"
+}
+
+get_yt_html () {
+    link="$1"
+    query="$2"
+    yt_html="$(
+	curl "$link" -s \
+	  -G --data-urlencode "search_query=$query" \
+	  -G --data-urlencode "sp=$sp" \
+	  -H 'authority: www.youtube.com' \
+	  -H "user-agent: $useragent" \
+	  -H 'accept-language: en-US,en;q=0.9' \
+	  --compressed
+    )"
+    if [ -z "$yt_html" ]; then
+	    print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
+	    exit 1 
+    fi
+}
+
+get_video_data () {
+	#in that list this finds the title, channel, view count, video length, video upload date, and the video id/url
+	videos_data="$(printf "%s" "$videos_json" |\
+		jq -r '.[]| (
+			.title,
+			.channel,
+			.views,
+			.duration,
+			.date,
+			.videoID
+			)' | sed "N;N;N;N;N;s/\n/""$(printf '\t')""\|/g")"
+	    #if there aren't videos
+	    [ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
+}
+
+scrape_subscriptions () {
+	for link in $*; do
+	    echo "Fetching $link" 
+	    get_yt_html "$link"
+	    #gets the channel name from title of page
+	    channel_name="$(echo "$yt_html" | grep -o '<title>.*</title>' | sed 's/<\/\?title>//g' | sed 's/ - YouTube//')"
+	    #gets json of videos
+	    get_yt_json
+	    #gets a list of videos
+	    videos_json="$(printf "%s" "$yt_json" |\
+	    jq '[ .contents | ..|.gridVideoRenderer? | 
+	    select(. !=null) | 
+		{
+			title: .title.runs[0].text,
+			channel:"'"$channel_name"'",
+			duration:.thumbnailOverlays[0].thumbnailOverlayTimeStatusRenderer.text.simpleText,
+			views: .shortViewCountText.simpleText,
+			date: .publishedTimeText.simpleText,
+			videoID: .videoId,
+			thumbs: .thumbnail.thumbnails[0].url,
+		}
+	    ]')"
+
+	    #gets new videos and thumbnails
+	    #if select all is on, keep all the results
+
+	    temp_videos_data="$videos_data"
+
+	    get_video_data
+
+	    #if not select all, or random select, get only the needed videos
+	    if [ $select_all -eq 0 -a $random_select -eq 0 ]; then
+		videos_data="$(echo "$videos_data" | sed ${link_count}q)"
+		videos_json="$(echo "$videos_json" | jq '.[0:'$link_count']')"
+	    fi
+
+	    #run user selection on the currently found urls that way it runs -a, etc.. on each subscription instead of once
+	    [ $auto_select -eq 1 -o $random_select -eq 1 -o $select_all -eq 1 ] && user_selection
+	    #gets all subscription urls before playing them in video player and before showing links_only
+	    subscription_urls="$subscription_urls\n$urls"
+	    
+	    new_thumb_urls="$(printf "%s" "$videos_json" | jq -r '.[]|(.thumbs,.videoID)')"
+	    #adds new thumbnails to old thumbnails
+	    thumb_urls="$new_thumb_urls
+$thumb_urls"
+	    #adds the new videos to the previously gotten videos
+	    [ -n "$temp_videos_data" ] && videos_data="$(printf "%s\n%s" "$temp_videos_data" "$videos_data")"
+
+	done
+	[ $show_link_only -eq 1 ] && echo "$(echo "$subscription_urls" | sed 1d)" && exit
+	[ $show_thumbnails -eq 1 ] && download_thumbnails "$thumb_urls"
+}
 scrape_yt () {
 	# needs search_query
 	## Scrape data and store video information in videos_data ( and thumbnails download)
@@ -423,24 +521,9 @@ scrape_yt () {
 		sp="${sp%%%*}"
 	fi
 
-	yt_html="$(
-	curl 'https://www.youtube.com/results' -s \
-	  -G --data-urlencode "search_query=$*" \
-	  -G --data-urlencode "sp=$sp" \
-	  -H 'authority: www.youtube.com' \
-	  -H "user-agent: $useragent" \
-	  -H 'accept-language: en-US,en;q=0.9' \
-	  --compressed
-	)"
-	#if there's no html
-	if [ -z "$yt_html" ]; then
-		print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
-		exit 1 
-	fi
+	get_yt_html "https://www.youtube.com/results" "$*"
 
-	#youtube has a bunch of data relating to videos in a json format, this scrapes that
-	yt_json="$(printf "%s" "$yt_html" | sed -n '/var *ytInitialData/,$p' | tr -d '\n' |\
-        sed -E ' s_^.*var ytInitialData ?=__ ; s_;</script>.*__ ;')"
+	get_yt_json
 
 	#if the data couldn't be found
 	if [ -z "$yt_json" ]; then  
@@ -463,19 +546,7 @@ scrape_yt () {
 		}
 	]')"
 
-	#in that list this finds the title, channel, view count, video length, video upload date, and the video id/url
-	videos_data="$(printf "%s" "$videos_json" |\
-		jq -r '.[]| (
-			.title,
-			.channel,
-			.views,
-			.duration,
-			.date,
-			.videoID
-			)' | sed "N;N;N;N;N;s/\n/""$(printf '\t')""\|/g")"
-
-	#if there aren't videos
-	[ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
+	get_video_data
 
 	[ $show_thumbnails -eq 1 ] && download_thumbnails
 }
@@ -544,7 +615,8 @@ EOF
 	#sometimes % shows up in selected data, could throw an error if it's an invalid directive
 	selected_data="$( printf "$selected_data" | sed 1d )"
 
-	if [ $show_link_only -eq 1 ] ; then
+	#if getting subscriptions, this will echo urls too early
+	if [ $show_link_only -eq 1 -a $get_subscriptions -eq 0 ] ; then
 		echo "$urls"
 		exit
 	fi
@@ -559,6 +631,9 @@ EOF
 play_url () {
 	#> output the current track to current file before playing
 	[ $YTFZF_CUR -eq 1 ] && printf "$selected_data" > "$current_file" ;
+
+	#if the subscription_urls have word characters, then use them as the urls
+	[ -n "$(echo "$subscription_urls" | grep -o '\w')" ] && urls="$(echo "$subscription_urls" | sed 1d)"
 
 	#> The urls are quoted and placed one after the other for mpv to read
 	player_urls="\"$(printf "$urls" | awk  'ORS="\" \"" { print }' | sed 's/"$//' )"
@@ -747,6 +822,8 @@ parse_opt () {
 
 		s)	search_again=1 ;;
 
+		S)	get_subscriptions=1 ;;
+
 		l) 	YTFZF_LOOP=1 ;;
 
 		t) 	show_thumbnails=1 ;;
@@ -769,13 +846,14 @@ parse_opt () {
 	esac
 }
 
-while getopts "LhDmdfxHaArltsvn:U:-:" opt; do
+while getopts "LhDmdfxHaArltSsvn:U:-:" opt; do
     parse_opt "$opt" "$OPTARG"
 done
 shift $((OPTIND-1))
 
 #if stdin is given and no input (including -) is given, throw error
-if [ ! -t 0 -a -z "$*" ]; then
+#also make sure it's not reading from ext_menu
+if [ ! -t 0 -a -z "$*" -a $is_ext_menu -eq 0 ]; then
 	printf "\033[31mERROR[#04]: Use - when reading from stdin\033[000m\n"
 	exit 1
 #read stdin if given
@@ -795,7 +873,12 @@ check_if_url "${search_query:=$*}"
 format_menu 
 
 #call scrape function
-if [ $scrape -eq 1 ]; then 
+if [ $get_subscriptions -eq 1 ]; then
+	if [ $auto_select -eq 1 -o $random_select -eq 1 -o $select_all -eq 1 ]; then
+	    fancy_subscriptions_menu=0
+	fi
+	scrape_subscriptions
+elif [ $scrape -eq 1 ]; then 
 	get_search_query
 	scrape_yt "$search_query"
 fi

--- a/ytfzf
+++ b/ytfzf
@@ -524,7 +524,6 @@ scrape_yt () {
 	printf "%s" "$videos_data\n" >> "$tmp_video_data_file"
 
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
-	wait
 }
 
 

--- a/ytfzf
+++ b/ytfzf
@@ -53,7 +53,7 @@ config_file="$config_dir/conf.sh"
 history_file="$YTFZF_CACHE/ytfzf_hst"
 current_file="$YTFZF_CACHE/ytfzf_cur"
 thumb_dir="$YTFZF_CACHE/thumb"
-subscriptions_file="${subscriptions_file-$config_dir/subscriptions.json}"
+subscriptions_file="${subscriptions_file-$config_dir/subscriptions}"
 
 #> stores the pid of running ytfzf sessions
 pid_file="$YTFZF_CACHE/.pid"
@@ -66,8 +66,6 @@ thumb_dir="$YTFZF_CACHE/thumb"
 search_prompt="${search_prompt-Search Youtube: }"
 #used when getting the html from youtube
 useragent=${useragent-'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36'}
-#instead of just a list of videos, add some titles
-fancy_subscriptions_menu=${fancy_subscriptions_menu-1}
 
 #Opt variables (can also be set in config)
 #use $YTFZF_EXT_MENU (same as -D)
@@ -90,7 +88,7 @@ link_count=${link_count-1}
 search_again=${search_again-0}
 #filter id used when searching
 sp="${sp-}"
-#scrape subscriptions.json file instead of a search query
+#scrape subscriptions file instead of a search query
 get_subscriptions=0
 
 #ueberzug related variables
@@ -272,20 +270,6 @@ format_video_data () {
 
 }
 
-format_video_json () {
-    #in videos_json this finds the title, channel, view count, video length, video upload date, and the video id/url
-	#then this formats it to how it appears in the selection menu
-    printf "%s" "$*" |\
-	    jq -r '.[]| (
-		.title,
-		.channel,
-		.views,
-		.duration,
-		.date,
-		.videoID
-		)' | sed "N;N;N;N;N;s/\n/""$(printf '\t')""\|/g"
-}
-
 ############################
 #   Video selection Menu   #
 ############################
@@ -319,11 +303,12 @@ stop_ueberzug () {
 }
 
 preview_img () {
-	shorturl="$(echo "$*" | sed -E -e 's_^.*\|__')"
+       shorturl="$(echo "$*" | sed -E -e 's_^.*\|__')"
 
-	thumb_width=$WIDTH
-	thumb_height=$((HEIGHT - 2))
-	#most common x, y positions
+       thumb_width=$WIDTH
+       thumb_height=$((HEIGHT - 2))
+       #most common x, y positions
+
 	thumb_x=$((TTY_COLS / 2 + 3))
 	thumb_y=10
 	case "$PREVIEW_SIDE" in
@@ -356,8 +341,9 @@ preview_img () {
 ############################
 
 download_thumbnails () {
-	#scrapes the urls of the thumbnails of the videos
-	thumb_urls="$1"
+       #scrapes the urls of the thumbnails of the videos from the adjusted json
+       thumb_urls="$(printf "%s" "$*" |\
+               jq  -r '.[]|(.thumbs,.videoID)' )"
 
 	[ "$show_link_only" -eq 0 ] && printf "Downloading Thumbnails"
     
@@ -455,58 +441,41 @@ get_video_data () {
 			)' | sed "N;N;N;N;N;s/\n/""$(printf '\t')""\|/g"
 }
 
-scrape_subscriptions () {
-	for link in $*; do
-	    echo "Fetching $link" 
-	    yt_html="$(get_yt_html "$link")"
-	    if [ -z "$yt_html" ]; then
-		    print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
-		    exit 1 
-	    fi
-	    #gets the channel name from title of page
-	    channel_name="$(echo "$yt_html" | grep -o '<title>.*</title>' | sed 's/<\/\?title>//g' | sed 's/ - YouTube//')"
-	    #gets json of videos
-	    yt_json="$(get_yt_json "$yt_html")"
-	    #gets a list of videos
-	    videos_json="$(printf "%s" "$yt_json" |\
-	    jq '[ .contents | ..|.gridVideoRenderer? | 
-	    select(. !=null) | 
-		{
-			title: .title.runs[0].text,
-			channel:"'"$channel_name"'",
-			duration:.thumbnailOverlays[0].thumbnailOverlayTimeStatusRenderer.text.simpleText,
-			views: .shortViewCountText.simpleText,
-			date: .publishedTimeText.simpleText,
-			videoID: .videoId,
-			thumbs: .thumbnail.thumbnails[0].url,
-		}
-	    ]')"
+scrape_channel () {
+	yt_html="$(get_yt_html "$*")"
+	
+	if [ -z "$yt_html" ]; then
+	        print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
+	        exit 1 
+	fi
 
-	    #gets new videos and thumbnails
-	    #if select all is on, keep all the results
+	#gets the channel name from title of page
+	channel_name="$(echo "$yt_html" | grep -o '<title>.*</title>' | sed 's/<\/\?title>//g' | sed 's/ - YouTube//')"
 
-	    temp_videos_data="$videos_data"
+	#gets json of videos
+	yt_json="$(get_yt_json "$yt_html")"
 
-	    videos_data="$(get_video_data "$videos_json")"
-	    #if there aren't videos
-	    [ -z "$videos_data" ] &&  { printf "No results found. Make sure the link is correct.\n"; exit 1;}
-
-	    #if not select all, or random select, get only the needed videos
-	    if [ $select_all -eq 0 -a $random_select -eq 0 ]; then
-		videos_data="$(echo "$videos_data" | sed ${link_count}q)"
-		videos_json="$(echo "$videos_json" | jq '.[0:'$link_count']')"
-	    fi
-
-	    #run user selection on the currently found urls that way it runs -a, etc.. on each subscription instead of once
-	    [ $auto_select -eq 1 -o $random_select -eq 1 -o $select_all -eq 1 ] && user_selection
-	    
-	    thumb_urls="$(printf "%s" "$videos_json" | jq -r '.[]|(.thumbs,.videoID)')"
-	    #adds the new videos to the previously gotten videos
-	    [ -n "$temp_videos_data" ] && videos_data="$(printf "%s\n%s" "$temp_videos_data" "$videos_data")"
-	    [ $show_thumbnails -eq 1 ] && download_thumbnails "$thumb_urls" &
-
-	done
-	wait
+	#gets a list of videos
+	videos_json="$(printf "%s" "$yt_json" |\
+	jq '[ .contents | ..|.gridVideoRenderer? | 
+	select(. !=null) | 
+	    {
+	    	title: .title.runs[0].text,
+	    	channel:"'"$channel_name"'",
+	    	duration:.thumbnailOverlays[0].thumbnailOverlayTimeStatusRenderer.text.simpleText,
+	    	views: .shortViewCountText.simpleText,
+	    	date: .publishedTimeText.simpleText,
+	    	videoID: .videoId,
+	    	thumbs: .thumbnail.thumbnails[0].url,
+	    }
+	]')"
+	
+	videos_data="$(get_video_data "$videos_json")"
+	
+	#if there aren't videos
+	[ -z "$videos_data" ] &&  { printf "No results found. Make sure the link is correct.\n"; exit 1;}
+	
+	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 }
 scrape_yt () {
 	# needs search_query
@@ -555,7 +524,7 @@ scrape_yt () {
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
 
-	[ $show_thumbnails -eq 1 ] && download_thumbnails "$(printf "%s" "$videos_json" | jq  -r '.[]|(.thumbs,.videoID)' )"
+	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 }
 
 
@@ -878,16 +847,11 @@ check_if_url "${search_query:=$*}"
 #format the menu screen
 format_menu 
 
-#call scrape function
-if [ $get_subscriptions -eq 1 ]; then
-	if [ $auto_select -eq 1 -o $random_select -eq 1 -o $select_all -eq 1 ]; then
-	    fancy_subscriptions_menu=0
-	fi
-	scrape_subscriptions
-elif [ $scrape -eq 1 ]; then 
+if [ $scrape -eq 1 ]; then 
 	get_search_query
 	scrape_yt "$search_query"
 fi
+#scrape_channel "https://www.youtube.com/user/PewDiePie/videos"
 
 while true; do
 	user_selection

--- a/ytfzf
+++ b/ytfzf
@@ -502,7 +502,6 @@ $thumb_urls"
 	    [ -n "$temp_videos_data" ] && videos_data="$(printf "%s\n%s" "$temp_videos_data" "$videos_data")"
 
 	done
-	[ $show_link_only -eq 1 ] && exit
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$thumb_urls"
 }
 scrape_yt () {
@@ -616,7 +615,6 @@ EOF
 	#if getting subscriptions, this will echo urls too early
 	if [ $show_link_only -eq 1 ] ; then
 		echo "$urls"
-		[ $get_subscriptions -eq 0 ] && exit
 	fi
 
 	# select format if flag given
@@ -880,6 +878,7 @@ fi
 
 while true; do
 	user_selection
+	[ $show_link_only -eq 1 ] && exit
 	play_url
 	save_before_exit
 	

--- a/ytfzf
+++ b/ytfzf
@@ -834,10 +834,10 @@ parse_long_opt () {
 		update) update_ytfzf "master" ;;
 		update-unstable) update_ytfzf "development" ;;
 
-		sub) parse_opt "S" ;;
-		sub=*)	
+		subs) parse_opt "S" ;;
+		subs=*)	
 			sub_link_count="${opt#*=}" 
-			is_non_number "$sub_link_count" && bad_opt_arg "--sub" "$sub_link_count"
+			is_non_number "$sub_link_count" && bad_opt_arg "--subs" "$sub_link_count"
 			parse_opt "S"
 			;;
 

--- a/ytfzf
+++ b/ytfzf
@@ -11,7 +11,7 @@ YTFZF_VERSION="1.0.1"
 ############################
 
 
-#>reading the config file 
+#>reading the config file
 config_dir="$HOME/.config/ytfzf"
 config_file="$config_dir/conf.sh"
 tmp_video_data_file="/tmp/ytfzf-subdata"
@@ -65,7 +65,7 @@ thumb_dir="$YTFZF_CACHE/thumb"
 [ -d "$YTFZF_CACHE" ] || mkdir -p "$YTFZF_CACHE"
 [ -d "$thumb_dir" ] || mkdir -p "$thumb_dir"
 
-#> config settings 
+#> config settings
 search_prompt="${search_prompt-Search Youtube: }"
 #used when getting the html from youtube
 useragent=${useragent-'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36'}
@@ -108,7 +108,7 @@ scrape="${scrape-yt_search}"
 #variable used for when this process spawns subprocesses and there needs to be a unique value (ueberzug)
 #this could be any unique value, $$ is used because it is the most easily accessible unique value
 if [ -z "$PROC_ID" ] ; then
-	export PROC_ID="$$" 
+	export PROC_ID="$$"
 	echo "$$" >> "$pid_file"
 fi
 
@@ -131,7 +131,7 @@ helpinfo () {
 printf "Usage: %bytfzf [OPTIONS] %b<search-query>%b\n" "\033[1;32m" "\033[1;33m" "\033[0m";
 printf "  OPTIONS:\n"
 printf "     -h, --help                           Show this help text\n";
-printf "     -v, --version                        -v for ytfzf's version\n"; 
+printf "     -v, --version                        -v for ytfzf's version\n";
 printf "                                          --version for ytfzf + dependency's versions\n"
 printf "     -t, --thumbnails                     Show thumbnails (requires ueberzug)\n";
 printf "                                          Doesn't work with -H -D\n";
@@ -208,6 +208,16 @@ print_error () {
 ############################
 #        Formatting        #
 ############################
+#> Colors  (printf)
+c_red="\033[1;31m"
+c_green="\033[1;32m"
+c_yellow="\033[1;33m"
+c_blue="\033[1;34m"
+c_magenta="\033[1;35m"
+c_cyan="\033[1;36m"
+c_reset="\033[0m"
+
+
 #> To determine the length of each field (title, channel ... etc)
 format_ext_menu () {
 	#base how much space everything takes up depending on the width of YTFZF_EXT_MENU
@@ -266,7 +276,7 @@ format_menu () {
 		#dep_ck fzf here because it is only necessary to use here
 		dep_ck "fzf"
 		menu_command='fzf -m --bind change:top --tabstop=1 --layout=reverse --delimiter="$(printf "\t")" --nth=1,2 $FZF_DEFAULT_OPTS'
-		format_fzf 
+		format_fzf
 	else
 		# dmenu doesnt render tabs so removing it
 		menu_command='tr -d "$(printf "\t")" | '"$YTFZF_EXTMENU"
@@ -314,12 +324,21 @@ stop_ueberzug () {
 }
 
 preview_img () {
-	shorturl="$( printf "%s" "$*" | sed -E -n -e 's_^.*\|([^|]+) *_\1_p')"
+	preview_data="$( printf '%s' "$*" | sed "s/ *""$(printf '\t|')""/""$(printf '\t')""/g" )"
+	title="$( printf '%s' "$preview_data" | cut -d"$(printf '\t')" -f1 )"
+	channel="$( printf '%s' "$preview_data" | cut -d"$(printf '\t')" -f2 )"
+	duration="$( printf '%s' "$preview_data" | cut -d"$(printf '\t')" -f3 )"
+	views="$( printf '%s' "$preview_data" | cut -d"$(printf '\t')" -f4 )"
+	date="$( printf '%s' "$preview_data" | cut -d"$(printf '\t')" -f5 )"
+	shorturl="$( printf '%s' "$preview_data" | cut -d"$(printf '\t')" -f6 | sed 's/ *//g' )"
 
-       if [ -z "$shorturl" ] ; then
+       if [ -z "${shorturl}" ] ; then
+	       printf "\n${c_cyan}%s${c_reset}\n" "$title"
 	       printf '{ "action": "remove", "identifier": "%s" }\n' "$ID" > "$FIFO"
 	       return
 	fi
+
+	printf "\n${c_cyan}%s\n${c_blue}Channel  ${c_green}%s\n${c_blue}Duration ${c_yellow}%s\n${c_blue}Views    ${c_magenta}%s\n${c_blue}Date     ${c_cyan}%s${c_reset}" "$title" "$channel" "$duration" "$views" "$date"
 
 
 	thumb_width=$WIDTH
@@ -347,9 +366,8 @@ preview_img () {
 	{   printf '{ "action": "add", "identifier": "%s", "path": "%s",' "$ID" "$IMAGE"
 	    printf '"x": %d, "y": %d, "scaler": "fit_contain",' $thumb_x $thumb_y
 	    printf '"width": %d, "height": %d }\n' "$thumb_width" "$thumb_height"
-	} > "$FIFO" 
-	echo "$*" |  tr -d '|' | sed "s/ *""$(printf '\t')""/""$(printf '\t')""/g" | awk -F"$(printf '\t')" \
-	'{ printf "\n%s\nChannel: %s\nViews: %s\nDuration: %s\nUploaded %s\n",$1,$2,$3,$4,$5}'
+	} > "$FIFO"
+
 }
 
 
@@ -364,12 +382,12 @@ download_thumbnails () {
 	i=0
 	while read -r line; do
 		if [ $((i % 2)) -eq 0 ]; then
-			url="$line" 
+			url="$line"
 			sleep 0.002
 		else
 			name="$line"
-			{ 
-				curl -s "$url" > "$thumb_dir/$name.png" 
+			{
+				curl -s "$url" > "$thumb_dir/$name.png"
 			} &
 		fi
 		i=$((i + 1))
@@ -458,10 +476,10 @@ scrape_channel () {
 	# needs channel url as $*
 	## Scrape data and store video information in videos_data ( and thumbnails )
 	yt_html="$(get_yt_html "$*")"
-	
+
 	if [ -z "$yt_html" ]; then
 	        print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
-	        exit 1 
+	        exit 1
 	fi
 
 	#gets the channel name from title of page
@@ -472,7 +490,7 @@ scrape_channel () {
 		-e "s/&quot;/\"/g" \
 		-e "s/&#34;/\"/g" \
 		-e "s/&amp;/\&/g" \
-		-e "s/&#38;/\&/g" 
+		-e "s/&#38;/\&/g"
 		)"
 
 	#gets json of videos
@@ -480,8 +498,8 @@ scrape_channel () {
 
 	#gets a list of videos
 	videos_json="$(printf "%s" "$yt_json" |\
-	jq '[ .contents | ..|.gridVideoRenderer? | 
-	select(. !=null) | 
+	jq '[ .contents | ..|.gridVideoRenderer? |
+	select(. !=null) |
 	    {
 	    	title: .title.runs[0].text,
 	    	channel:"'"$channel_name"'",
@@ -492,7 +510,7 @@ scrape_channel () {
 	    	thumbs: .thumbnail.thumbnails[0].url,
 	    }
 	]')"
-	
+
 	videos_json="$(echo "$videos_json" | jq '.[0:'$sub_link_count']')"
 	videos_data="$(get_video_data "$videos_json")"
 
@@ -504,7 +522,7 @@ scrape_channel () {
 	else
 		printf "%s\n" "$videos_data" >> "$tmp_video_data_file"
 	fi
-	
+
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 }
 scrape_yt () {
@@ -523,21 +541,21 @@ scrape_yt () {
 	yt_html="$(get_yt_html "https://www.youtube.com/results" "$*")"
 	if [ -z "$yt_html" ]; then
 		print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[000m\n"
-		exit 1 
+		exit 1
 	fi
 
 	yt_json="$(get_yt_json "$yt_html")"
 
 	#if the data couldn't be found
-	if [ -z "$yt_json" ]; then  
+	if [ -z "$yt_json" ]; then
 		print_error "\033[31mERROR[#02]: Couldn't find data on site.\033[000m\n"
 		exit 1
 	fi
 
 	#gets a list of videos
-	videos_json="$(printf "%s" "$yt_json" | jq '[ .contents| 
-	..|.videoRenderer? | 
-	select(. !=null) | 
+	videos_json="$(printf "%s" "$yt_json" | jq '[ .contents|
+	..|.videoRenderer? |
+	select(. !=null) |
 		{
 			title: .title.runs[0].text,
 			channel: .longBylineText.runs[0].text,
@@ -566,7 +584,7 @@ scrape_yt () {
 get_search_query () {
 	#in case no query was provided
 	if [ -z "$search_query" ]; then
-		if [ "$is_ext_menu" -eq 1 ]; then 
+		if [ "$is_ext_menu" -eq 1 ]; then
 			#when using an external menu, the query will be done there
 			search_query="$(printf "" | $YTFZF_EXTMENU)"
 		else
@@ -601,14 +619,14 @@ user_selection () {
 		--layout=reverse --preview \"sh $0 -U {}\" \
         	--preview-window \"$PREVIEW_SIDE:50%:noborder:wrap\""
 		selected_data="$( title_len=200 video_menu "$videos_data" )"
-		stop_ueberzug 
+		stop_ueberzug
 		# Deletes thumbnails if no video is selected
-		[ -z "$selected_data" ] && delete_thumbnails 
+		[ -z "$selected_data" ] && delete_thumbnails
 	#show regular menu
 	else
 		selected_data="$( video_menu "$videos_data" )"
 	fi
-	
+
 	#gets a list of video ids/urls from the selected data
 	shorturls="$(echo "$selected_data" | sed -E -n -e "s_.*\|([^|]+) *\$_\1_p")"
 	[ -z "$shorturls" ] && exit;
@@ -634,11 +652,11 @@ EOF
 	fi
 
 	# select format if flag given
-	if [ "$show_format" -eq 1 ]; then 
+	if [ "$show_format" -eq 1 ]; then
 		YTFZF_PREF="$(youtube-dl -F "$(printf "%s" "$urls" | sed 1q)" | sed '1,3d' | tac - |\
 		eval "$menu_command" | sed -E 's/^([^ ]*) .*/\1/')"
 		[ -z "$YTFZF_PREF"  ] && exit;
-	fi	
+	fi
 }
 play_url () {
 	#> output the current track to current file before playing
@@ -683,7 +701,7 @@ save_before_exit () {
 check_if_url () {
 	# to check if given input is a url
 	url_regex='^https\?://.*'
-	
+
 	if { echo "$1" | grep -q "$url_regex"; } ; then
 		is_url=1
 		urls="$(echo "$1" | tr ' ' '\n')"
@@ -721,8 +739,8 @@ update_ytfzf () {
 	updatefile="/tmp/ytfzf-update"
 	curl "https://raw.githubusercontent.com/pystardust/ytfzf/$branch/ytfzf" > "$updatefile"
 	chmod 755 "$updatefile"
-	if [ "$(uname)" = "Darwin" ]; then 
-	    sudo cp "$updatefile" "/usr/local/bin/ytfzf" 
+	if [ "$(uname)" = "Darwin" ]; then
+	    sudo cp "$updatefile" "/usr/local/bin/ytfzf"
 	else
 	    sudo cp "$updatefile" "/usr/bin/ytfzf"
 	fi
@@ -745,7 +763,7 @@ EOF
 
 is_non_number () {
     if [ -n "$(echo "$1" | grep -o '[^0-9]')" ]; then
-	return 0 
+	return 0
     else
 	return 1
     fi
@@ -766,7 +784,7 @@ parse_long_opt () {
 	        help) parse_opt "h" ;;
 
 		ext-menu) parse_opt "D" ;;
-		ext-menu=*) 
+		ext-menu=*)
 		    parse_opt "D" "${opt#*=}"
 		    is_non_number "$is_ext_menu" && bad_opt_arg "--ext-menu=" "$is_ext_menu" ;;
 
@@ -777,22 +795,22 @@ parse_long_opt () {
 		clear-history) parse_opt "x" ;;
 
 		search) parse_opt "s" ;;
-		search=*) 
+		search=*)
 		    parse_opt "s" "${opt#*=}"
 		    is_non_number "$search_again" && bad_opt_arg "--search=" "$search_again" ;;
 
 		loop) parse_opt "l" ;;
-		loop=*) 
+		loop=*)
 		    parse_opt "l" "${opt#*=}"
 		    is_non_number "$YTFZF_LOOP" && bad_opt_arg "--loop=" "$YTFZF_LOOP" ;;
 
 		thumbnails) parse_opt "t" ;;
-		thumbnails=*) 
-		    parse_opt "t" "${opt#*=}" 
+		thumbnails=*)
+		    parse_opt "t" "${opt#*=}"
 		    is_non_number "$show_thumbnails" && bad_opt_arg "--thumbnails=" "$show_thumbnails" ;;
 
 		link-only) parse_opt "L" ;;
-		link-only=*) 
+		link-only=*)
 		    parse_opt "L" "${opt#*=}"
 		    is_non_number "$show_link_only" && bad_opt_arg "--link-only=" "$show_link_only" ;;
 
@@ -801,17 +819,17 @@ parse_long_opt () {
 		audio-only) parse_opt "m" ;;
 
 		auto-play) parse_opt "a" ;;
-		auto-play=*) 
+		auto-play=*)
 		    parse_opt "a" "${opt#*=}"
 		    is_non_number "$auto_select" && bad_opt_arg "--auto-play=" "$auto_select" ;;
-    
+
 		select-all) parse_opt "A" ;;
-		select-all=*) 
+		select-all=*)
 		    parse_opt "A" "${opt#*=}"
 		    is_non_number "$select_all" && bad_opt_arg "--select-all=" "$select_all" ;;
 
 		random-play) parse_opt "r" ;;
-		random-play=*) 
+		random-play=*)
 		    parse_opt "r" "${opt#*=}"
 		    is_non_number "$random_select" && bad_opt_arg "--random-play=" "$random_select" ;;
 
@@ -835,8 +853,8 @@ parse_long_opt () {
 		update-unstable) update_ytfzf "development" ;;
 
 		subs) parse_opt "S" ;;
-		subs=*)	
-			sub_link_count="${opt#*=}" 
+		subs=*)
+			sub_link_count="${opt#*=}"
 			is_non_number "$sub_link_count" && bad_opt_arg "--subs" "$sub_link_count"
 			parse_opt "S"
 			;;
@@ -844,12 +862,12 @@ parse_long_opt () {
 		fancy-subs) fancy_subscriptions_menu=1 ;;
 		fancy-subs=*) fancy_subscriptions_menu="${opt#*=}" ;;
 
-		version) 
+		version)
 		    printf "\033[1mytfzf:\033[000m %s\n" "$YTFZF_VERSION"
 		    printf "\033[1myoutube-dl:\033[00m %s\n" "$(youtube-dl --version)"
 		    command -v "fzf" 1>/dev/null && printf "\033[1mfzf:\033[000m %s\n" "$(fzf --version)"
 		    exit ;;
-				
+
 		*)
 		    printf "Illegal option --%s\n" "$opt"
 		    usageinfo
@@ -859,7 +877,7 @@ parse_long_opt () {
 parse_opt () {
 	#the first arg is the option
 	opt="$1"
-	#second arg is the optarg 
+	#second arg is the optarg
 	OPTARG="$2"
 	case ${opt} in
 		#Long options
@@ -900,8 +918,8 @@ parse_opt () {
 
 		L) 	show_link_only=${OPTARG:-1} ;;
 
-		n)	
-		    link_count="$OPTARG" 
+		n)
+		    link_count="$OPTARG"
 		    is_non_number "$link_count" && bad_opt_arg "-n" "$link_count" ;;
 
 		U) 	[ -p "$FIFO" ] && preview_img "$OPTARG"; exit;
@@ -940,24 +958,24 @@ elif [ "$*" = "-" ]; then
 	    search_query="$search_query $line"
 	done
 fi
-check_if_url "${search_query:=$*}" 
+check_if_url "${search_query:=$*}"
 
 # If in auto select mode dont download thumbnails
-[ $auto_select -eq 1 ] || [ $random_select -eq 1 ] && show_thumbnails=0; 
+[ $auto_select -eq 1 ] || [ $random_select -eq 1 ] && show_thumbnails=0;
 
 #format the menu screen
-format_menu 
+format_menu
 
 
 case "$scrape" in
-	"yt_search") 
+	"yt_search")
 		get_search_query
 		scrape_yt "$search_query" ;;
 	"yt_subs")
 		scrape_subscriptions
 		;;
-	"history") 
-		get_history 
+	"history")
+		get_history
 		;;
 esac
 
@@ -966,7 +984,7 @@ while true; do
 	user_selection
 	play_url
 	save_before_exit
-	
+
 	#if looping and searching_again arent on then exit
 	if [ $YTFZF_LOOP -eq 0 ] && [ $search_again -eq 0 ] ; then
 		delete_thumbnails

--- a/ytfzf
+++ b/ytfzf
@@ -350,8 +350,7 @@ preview_img () {
 
 download_thumbnails () {
 	#scrapes the urls of the thumbnails of the videos
-	[ -z "$1" ] && thumb_urls="$(printf "%s" "$videos_json" |\
-		jq  -r '.[]|(.thumbs,.videoID)' )"
+	thumb_urls="$1"
 
 	[ $show_link_only -eq 0 ] && printf "Downloading Thumbnails"
     
@@ -418,7 +417,7 @@ get_sp_filter () {
 
 get_yt_json () {
 	#youtube has a bunch of data relating to videos in a json format, this scrapes that
-	yt_json="$(printf "%s" "$yt_html" | sed -n '/var *ytInitialData/,$p' | tr -d '\n' |\
+	yt_json="$(printf "%s" "$*" | sed -n '/var *ytInitialData/,$p' | tr -d '\n' |\
         sed -E ' s_^.*var ytInitialData ?=__ ; s_;</script>.*__ ;')"
 }
 
@@ -442,7 +441,7 @@ get_yt_html () {
 
 get_video_data () {
 	#in that list this finds the title, channel, view count, video length, video upload date, and the video id/url
-	videos_data="$(printf "%s" "$videos_json" |\
+	videos_data="$(printf "%s" "$*" |\
 		jq -r '.[]| (
 			.title,
 			.channel,
@@ -462,7 +461,7 @@ scrape_subscriptions () {
 	    #gets the channel name from title of page
 	    channel_name="$(echo "$yt_html" | grep -o '<title>.*</title>' | sed 's/<\/\?title>//g' | sed 's/ - YouTube//')"
 	    #gets json of videos
-	    get_yt_json
+	    get_yt_json "$yt_html"
 	    #gets a list of videos
 	    videos_json="$(printf "%s" "$yt_json" |\
 	    jq '[ .contents | ..|.gridVideoRenderer? | 
@@ -483,7 +482,7 @@ scrape_subscriptions () {
 
 	    temp_videos_data="$videos_data"
 
-	    get_video_data
+	    get_video_data "$videos_json"
 
 	    #if not select all, or random select, get only the needed videos
 	    if [ $select_all -eq 0 -a $random_select -eq 0 ]; then
@@ -520,7 +519,7 @@ scrape_yt () {
 
 	get_yt_html "https://www.youtube.com/results" "$*"
 
-	get_yt_json
+	get_yt_json "$yt_html"
 
 	#if the data couldn't be found
 	if [ -z "$yt_json" ]; then  
@@ -543,9 +542,9 @@ scrape_yt () {
 		}
 	]')"
 
-	get_video_data
+	get_video_data "$videos_json"
 
-	[ $show_thumbnails -eq 1 ] && download_thumbnails
+	[ $show_thumbnails -eq 1 ] && download_thumbnails "$(printf "%s" "$videos_json" | jq  -r '.[]|(.thumbs,.videoID)' )"
 }
 
 

--- a/ytfzf
+++ b/ytfzf
@@ -500,15 +500,13 @@ scrape_subscriptions () {
 	    #run user selection on the currently found urls that way it runs -a, etc.. on each subscription instead of once
 	    [ $auto_select -eq 1 -o $random_select -eq 1 -o $select_all -eq 1 ] && user_selection
 	    
-	    new_thumb_urls="$(printf "%s" "$videos_json" | jq -r '.[]|(.thumbs,.videoID)')"
-	    #adds new thumbnails to old thumbnails
-	    thumb_urls="$new_thumb_urls
-$thumb_urls"
+	    thumb_urls="$(printf "%s" "$videos_json" | jq -r '.[]|(.thumbs,.videoID)')"
 	    #adds the new videos to the previously gotten videos
 	    [ -n "$temp_videos_data" ] && videos_data="$(printf "%s\n%s" "$temp_videos_data" "$videos_data")"
+	    [ $show_thumbnails -eq 1 ] && download_thumbnails "$thumb_urls" &
 
 	done
-	[ $show_thumbnails -eq 1 ] && download_thumbnails "$thumb_urls"
+	wait
 }
 scrape_yt () {
 	# needs search_query

--- a/ytfzf
+++ b/ytfzf
@@ -480,7 +480,7 @@ scrape_channel () {
 
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Make sure the link is correct.\n"; exit 1;}
-	printf "             -------%s-------\n%s\n" "$channel_name" \
+	printf "             -------%s-------\t\n%s\n" "$channel_name" \
 		"$videos_data" >> "$tmp_video_data_file"
 	
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
@@ -558,16 +558,18 @@ get_search_query () {
 #> To select videos from videos_data
 user_selection () {
 	[ "$is_url" -eq 1 ] && return
+	#remove subscription separators
+	videos_data_clean="$(printf "%s" "$videos_data" | sed "/.*""$(printf "\t")""$/d" )"
 
 	#$selected_data is the video the user picked
 	#picks the first n videos
 	if [ "$select_all" -eq 1 ] ; then
-		selected_data="$videos_data"
+		selected_data="$videos_data_clean"
 	elif [ "$auto_select" -eq 1 ] ; then
-		selected_data="$(echo "$videos_data" | sed "${link_count}"q )" ;
+		selected_data="$(printf "%s\n" "$videos_data_clean" | sed "${link_count}"q )" ;
 	#picks n random videos
 	elif [ "$random_select" -eq 1 ] ; then
-		selected_data="$(echo "$videos_data" | shuf -n "$link_count" )"
+		selected_data="$(printf "%s\n" "$videos_data_clean" | shuf -n "$link_count" )"
 	#show thumbnail menu
 	elif [ "$show_thumbnails" -eq 1 ] ; then
 		dep_ck "ueberzug" "fzf"
@@ -771,6 +773,12 @@ parse_long_opt () {
 		update) update_ytfzf "master" ;;
 		update-unstable) update_ytfzf "development" ;;
 
+		sub) parse_opt "S" ;;
+		sub=*)	
+			sub_link_count="${opt#*=}" 
+			parse_opt "S"
+			;;
+
 		version) 
 		    printf "\033[1mytfzf:\033[000m %s\n" "$YTFZF_VERSION"
 		    printf "\033[1myoutube-dl:\033[00m %s\n" "$(youtube-dl --version)"
@@ -827,7 +835,6 @@ parse_opt () {
 		L) 	show_link_only=1 ;;
 
 		n)	link_count="$OPTARG" 
-			sub_link_count="$OPTARG"
 			;;
 
 		U) 	[ -p "$FIFO" ] && preview_img "$OPTARG"; exit;

--- a/ytfzf
+++ b/ytfzf
@@ -55,6 +55,7 @@ printf "" > "$tmp_video_data_file"
 history_file="$YTFZF_CACHE/ytfzf_hst"
 current_file="$YTFZF_CACHE/ytfzf_cur"
 thumb_dir="$YTFZF_CACHE/thumb"
+#> Stores urls of the video page of channels
 subscriptions_file="${subscriptions_file-$config_dir/subscriptions}"
 
 #> stores the pid of running ytfzf sessions

--- a/ytfzf
+++ b/ytfzf
@@ -746,16 +746,24 @@ clear_history () {
 update_ytfzf () {
 	branch="$1"
 	updatefile="/tmp/ytfzf-update"
-	curl "https://raw.githubusercontent.com/pystardust/ytfzf/$branch/ytfzf" > "$updatefile"
-	chmod 755 "$updatefile"
-	if [ "$(uname)" = "Darwin" ]; then
-	    sudo cp "$updatefile" "/usr/local/bin/ytfzf"
+	curl -L "https://raw.githubusercontent.com/pystardust/ytfzf/$branch/ytfzf" -o "$updatefile"
+
+	if sed -n '1p' < "$updatefile" | grep -q '#!/bin/sh' ; then
+		chmod 755 "$updatefile"
+		if [ "$(uname)" = "Darwin" ]; then
+			sudo cp "$updatefile" "/usr/local/bin/ytfzf"
+		else
+			sudo cp "$updatefile" "/usr/bin/ytfzf"
+		fi
 	else
-	    sudo cp "$updatefile" "/usr/bin/ytfzf"
+		printf "%bFailed to update ytfzf. Try again later.%b" "$c_red" "$c_reset"
 	fi
+
 	rm "$updatefile"
 	exit
 }
+
+
 
 scrape_subscriptions () {
 	while read -r url; do

--- a/ytfzf
+++ b/ytfzf
@@ -404,11 +404,10 @@ download_thumbnails () {
 	while read -r line; do
 		if [ $((i % 2)) -eq 0 ]; then
 			url="$line"
-			sleep 0.002
 		else
 			name="$line"
 			{
-			    curl -s "$url" > "$thumb_dir/$name.png"
+				curl -s "$url" -G --data-urlencode "sqp=" > "$thumb_dir/$name.png"
 			} &
 		fi
 		i=$((i + 1))

--- a/ytfzf
+++ b/ytfzf
@@ -322,7 +322,7 @@ stop_ueberzug () {
     rm "$FIFO" > /dev/null 2>&1
 }
 
-if  [ -z "$(LANG=C type thumbnail_video_info_text | grep 'function')" ] ; then
+if ! type thumbnail_video_info_text > /dev/null; then
     thumbnail_video_info_text () {
 	printf "\n${c_cyan}%s" "$title"
 	printf "\n${c_blue}Channel	${c_green}%s" "$channel"

--- a/ytfzf
+++ b/ytfzf
@@ -456,7 +456,7 @@ get_video_data () {
 }
 
 scrape_subscriptions () {
-	for link in $*; do
+	for link in https://www.youtube.com/c/DistroTube/videos https://www.youtube.com/user/PewDiePie/videos; do
 	    echo "Fetching $link" 
 	    get_yt_html "$link"
 	    #gets the channel name from title of page
@@ -493,8 +493,6 @@ scrape_subscriptions () {
 
 	    #run user selection on the currently found urls that way it runs -a, etc.. on each subscription instead of once
 	    [ $auto_select -eq 1 -o $random_select -eq 1 -o $select_all -eq 1 ] && user_selection
-	    #gets all subscription urls before playing them in video player and before showing links_only
-	    subscription_urls="$subscription_urls\n$urls"
 	    
 	    new_thumb_urls="$(printf "%s" "$videos_json" | jq -r '.[]|(.thumbs,.videoID)')"
 	    #adds new thumbnails to old thumbnails
@@ -504,7 +502,7 @@ $thumb_urls"
 	    [ -n "$temp_videos_data" ] && videos_data="$(printf "%s\n%s" "$temp_videos_data" "$videos_data")"
 
 	done
-	[ $show_link_only -eq 1 ] && echo "$(echo "$subscription_urls" | sed 1d)" && exit
+	[ $show_link_only -eq 1 ] && exit
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$thumb_urls"
 }
 scrape_yt () {
@@ -616,9 +614,9 @@ EOF
 	selected_data="$( printf "$selected_data" | sed 1d )"
 
 	#if getting subscriptions, this will echo urls too early
-	if [ $show_link_only -eq 1 -a $get_subscriptions -eq 0 ] ; then
+	if [ $show_link_only -eq 1 ] ; then
 		echo "$urls"
-		exit
+		[ $get_subscriptions -eq 0 ] && exit
 	fi
 
 	# select format if flag given
@@ -631,9 +629,6 @@ EOF
 play_url () {
 	#> output the current track to current file before playing
 	[ $YTFZF_CUR -eq 1 ] && printf "$selected_data" > "$current_file" ;
-
-	#if the subscription_urls have word characters, then use them as the urls
-	[ -n "$(echo "$subscription_urls" | grep -o '\w')" ] && urls="$(echo "$subscription_urls" | sed 1d)"
 
 	#> The urls are quoted and placed one after the other for mpv to read
 	player_urls="\"$(printf "$urls" | awk  'ORS="\" \"" { print }' | sed 's/"$//' )"

--- a/ytfzf
+++ b/ytfzf
@@ -322,7 +322,7 @@ stop_ueberzug () {
     rm "$FIFO" > /dev/null 2>&1
 }
 
-if  [ -z "$(type thumbnail_video_info_text | grep 'function')" ] ; then
+if  [ -z "$(LANG=C type thumbnail_video_info_text | grep 'function')" ] ; then
     thumbnail_video_info_text () {
 	printf "\n${c_cyan}%s" "$title"
 	printf "\n${c_blue}Channel	${c_green}%s" "$channel"

--- a/ytfzf
+++ b/ytfzf
@@ -596,7 +596,7 @@ user_selection () {
 	fi
 	
 	#gets a list of video ids/urls from the selected data
-	shorturls="$(echo "$selected_data" | sed -E -e "s_.*\|([^|]+) *\$_\1_")"
+	shorturls="$(echo "$selected_data" | sed -E -n -e "s_.*\|([^|]+) *\$_\1_p")"
 	[ -z "$shorturls" ] && exit;
 
 	#for each url append the full url to the $urls string

--- a/ytfzf
+++ b/ytfzf
@@ -404,6 +404,7 @@ download_thumbnails () {
 	while read -r line; do
 		if [ $((i % 2)) -eq 0 ]; then
 			url="$line"
+			sleep 0.001
 		else
 			name="$line"
 			{

--- a/ytfzf
+++ b/ytfzf
@@ -524,6 +524,7 @@ scrape_yt () {
 	printf "%s" "$videos_data\n" >> "$tmp_video_data_file"
 
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
+	wait
 }
 
 

--- a/ytfzf
+++ b/ytfzf
@@ -4,7 +4,7 @@
 #> https://github.com/pystardust/ytfzf
 ######################################
 
-YTFZF_VERSION="1.0.1"
+YTFZF_VERSION="1.1.0"
 
 ############################
 #         Defaults         #

--- a/ytfzf
+++ b/ytfzf
@@ -718,8 +718,13 @@ update_ytfzf () {
 
 scrape_subscriptions () {
 	while read -r url; do
-		 scrape_channel "$url"  &
-	done < "$subscriptions_file"
+		scrape_channel "$url"  &
+	done << EOF
+$( sed \
+	-e "s/#.*//" \
+	-e "/^[[:space:]]*$/d" \
+	"$subscriptions_file")
+EOF
 	wait
 	videos_data="$(cat "$tmp_video_data_file")"
 }


### PR DESCRIPTION
# Features
* Subscriptions
    * subscriptions can be set with $subscriptions_file (~/.config/ytfzf/subscriptions by default)
    * a subscription is a link to a channel's video page, eg: https://www.youtube.com/user/PewDiePie/videos (see README)
* multiple urls for input
* channel name, views, etc... has color when using -t

# Changes
* not using - for stdin gives error code of 2 instead of 1
* --version now bolds each module, and prints the version of fzf if installed

# Bug fixes
* when reading from an external menu, ytfzf threw an error when it shouldn't have
* if -t was given, it didn't check if fzf was installed, it will now
* when -tD was given, it would switch to use fzf, instead it warns about external menus not having thumbnail support then continues
* history_file and current_file didn't work in conf.sh
* issue with tac on macos
* issue with YTFZF_PLAYER not being parsed correctly

> update log by @Euro20179 