### PR TITLE
fix+feat: add --notification= option, fix zsh complain syntax

### DIFF
--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -34,6 +34,11 @@ cache_dir="$HOME/.cache/ytfzf"
 #(YTFZF_CUR)
 enable_cur=1
 
+#enable/disable notification when play video
+#the notification is send via send-notify
+#(YTFZF_NOTI)
+enable_noti=1
+
 #the format of the video (1080p, 720p, etc)
 #uses the youtube-dl preference system
 #must be a number eg: 22 is 720p

--- a/ytfzf
+++ b/ytfzf
@@ -29,6 +29,8 @@ printf "" > "$tmp_video_data_file"
 [ -z "$YTFZF_LOOP" ] && YTFZF_LOOP=${enable_loop-0}
 #enable/disable outputting current track to $current_file
 [ -z "$YTFZF_CUR" ] && YTFZF_CUR=${enable_cur-1}
+#enable/disable notification
+[ -z "$YTFZF_NOTI" ] && YTFZF_NOTI=${enable_noti-1}
 #the cache directory
 [ -z "$YTFZF_CACHE" ] && YTFZF_CACHE="${cache_dir-$HOME/.cache/ytfzf}"
 #video type preference (mp4/1080p, mp4/720p, etc..)
@@ -151,6 +153,7 @@ basic_helpinfo () {
     printf "     -l, --loop           <search-query>    Loop: prompt selector again after video ends\n";
     printf "     -s, --search-again   <search-query>    After the video ends make another search \n";
     printf "     -L, --link-only      <search-query>    Prints the selected URL only, helpful for scripting\n";
+    printf "     -N, --notification   <0,1>  			Send notification when play video\n";
     printf "     --preview-side=      <left/right/top/bottom>    the side of the screen to show thumbnails\n";
     printf "\n"
     printf "  Use - instead of <search-query> for stdin\n" 
@@ -206,6 +209,7 @@ all_help_info () {
     printf "     YTFZF_EXTMENU=' dmenu -i -l 30'\n";
     printf "  To use rofi\n";
     printf "     YTFZF_EXTMENU=' rofi -dmenu -fuzzy -width 1500'\n";
+    printf "     YTFZF_NOTI=1						   0 : turn off notification\n";
     printf "\n";
 }
 
@@ -422,9 +426,13 @@ EOF
 download_thumbnails () {
        #scrapes the urls of the thumbnails of the videos from the adjusted json
 	if [ "$thumbnail_quality" -eq 1 ]; then
-		image_download () curl -s "$url" -G --data-urlencode "sqp=" > "$thumb_dir/$name.png"
+		image_download () {
+			curl -s "$url" -G --data-urlencode "sqp=" > "$thumb_dir/$name.png"
+		}
 	else
-		image_download () curl -s "$url"  > "$thumb_dir/$name.png"
+		image_download () {
+ 			curl -s "$url"  > "$thumb_dir/$name.png"
+		}
 	fi
 
 	[ "$show_link_only" -eq 0 ] && printf "Downloading Thumbnails...\n"
@@ -728,6 +736,8 @@ play_url () {
 
 	[ "$YTFZF_CUR" -eq 1 ] && printf "%s" "$selected_data" > "$current_file" ;
 
+	[ "$YTFZF_NOTI" -eq 1 ] && send_notify ;
+
 	#> The urls are quoted and placed one after the other for mpv to read
 	local player_urls="\"$(printf "%s" "$selected_urls" | awk  'ORS="\" \"" { print }' | sed 's/"$//' | sed 's/ "" / /')"
 	#> Play url with $player or $player_format based on options
@@ -798,6 +808,17 @@ clear_history () {
 		printf "\033[31mHistory file not found, history not cleared\033[0m\n"
 		exit 1
 	fi
+}
+
+send_notify () {
+	video_name=$(printf "$selected_data" | awk -F'|' '{print $1}')
+	video_channel=$(printf "$selected_data" | awk -F'|' '{print $2}')
+	if [ $show_thumbnails -eq 1 ]; then
+		video_thumb="$thumb_dir/$(printf "$selected_data" | awk -F'|' '{print $6}').png"
+	else
+		video_thumb="$config_dir/default_thumb.png"
+	fi
+	notify-send "Current playing" "$(printf "$video_name\nChannel: $video_channel")" -i $video_thumb
 }
 
 update_ytfzf () {
@@ -929,6 +950,8 @@ parse_long_opt () {
 		fancy-subs) fancy_subscriptions_menu=1 ;;
 		fancy-subs=*) fancy_subscriptions_menu="${opt#*=}" ;;
 
+		notification) parse_opt "N" ;;
+
 		version)
 		    printf "\033[1mytfzf:\033[0m %s\n" "$YTFZF_VERSION"
 		    printf "\033[1myoutube-dl:\033[0m %s\n" "$(youtube-dl --version)"
@@ -995,13 +1018,15 @@ parse_opt () {
 			# Not to be used explicitly
 			;;
 
+		N)	YTFZF_NOTI=${optarg:-1} ;;
+
 		*)
 			usageinfo
 			exit 2 ;;
 	esac
 }
 
-while getopts "LhDmdfxHaArltSsvn:U:-:" OPT; do
+while getopts "LhDmdfxHaArltSsvnN:U:-:" OPT; do
     parse_opt "$OPT" "$OPTARG"
 done
 shift $((OPTIND-1))

--- a/ytfzf
+++ b/ytfzf
@@ -811,14 +811,20 @@ clear_history () {
 }
 
 send_notify () {
+	number_video=`expr $(cat $current_file | wc -l) + 1`
 	video_name=$(printf "$selected_data" | awk -F'|' '{print $1}')
 	video_channel=$(printf "$selected_data" | awk -F'|' '{print $2}')
-	if [ $show_thumbnails -eq 1 ]; then
+	if [ $show_thumbnails -eq 1 ] && [ $number_video -lt 2 ]; then
 		video_thumb="$thumb_dir/$(printf "$selected_data" | awk -F'|' '{print $6}').png"
+		message="$(printf "$video_name\nChannel: $video_channel")"
+	elif [ $number_video -gt 1 ]; then
+		video_thumb="$config_dir/default_thumb.png"
+		message="Added $number_video video to play queue"
 	else
+		message="$(printf "$video_name\nChannel: $video_channel")"
 		video_thumb="$config_dir/default_thumb.png"
 	fi
-	notify-send "Current playing" "$(printf "$video_name\nChannel: $video_channel")" -i $video_thumb
+	notify-send "Current playing" "$message" -i $video_thumb
 }
 
 update_ytfzf () {

--- a/ytfzf
+++ b/ytfzf
@@ -137,7 +137,8 @@ basic_helpinfo () {
     printf "     -h, --help                             Show this help text\n";
     printf "     -v, --version                          -v for ytfzf's version\n";
     printf "                                            --version for ytfzf + dependency's versions\n"
-    printf "     -t, --show-thumbnails                       Show thumbnails (requires ueberzug)\n";
+    printf "     -t, --show-thumbnails                  Show thumbnails (requires ueberzug)\n";
+    printf "     -N, --notification                     Send notification when play video\n";
     printf "                                            Doesn't work with -H -D\n";
     printf "     --thumbnail-quality=<0,1>              0: low quality (faster), 1: default\n"
     printf "     -D, --ext-menu                         Use external menu(default dmenu) instead of fzf \n";
@@ -153,7 +154,6 @@ basic_helpinfo () {
     printf "     -l, --loop           <search-query>    Loop: prompt selector again after video ends\n";
     printf "     -s, --search-again   <search-query>    After the video ends make another search \n";
     printf "     -L, --link-only      <search-query>    Prints the selected URL only, helpful for scripting\n";
-    printf "     -N, --notification   <0,1>  			Send notification when play video\n";
     printf "     --preview-side=      <left/right/top/bottom>    the side of the screen to show thumbnails\n";
     printf "\n"
     printf "  Use - instead of <search-query> for stdin\n" 
@@ -1026,7 +1026,7 @@ parse_opt () {
 	esac
 }
 
-while getopts "LhDmdfxHaArltSsvnN:U:-:" OPT; do
+while getopts "LhDmdfxHaArltSsvNn:U:-:" OPT; do
     parse_opt "$OPT" "$OPTARG"
 done
 shift $((OPTIND-1))


### PR DESCRIPTION
- Add enable_noti=<1:default, 2> config that enable notification feature
- Add flag -N --notification <0,1> enable/disable notification feature
- Add notification flag -h entry
- If enable notification & thumbnails it will use thumbnail as notification icon else it will use default thumbnail icon (user defined) file at ./config/ytfzf/default_thumb.png
- Fix zsh complain syntax at download_thumbnails