### PR TITLE
[Proposal] Changing the video format menu.

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -724,11 +724,11 @@ print_data () {
 get_video_format () {
 	# select format if flag given
 	if [ $show_format -eq 1 ]; then 
-		        max_quality=$(youtube-dl -F "$(printf "$selected_urls")" | awk '{print $3}' | cut -dx -f2 | sort -n | tail -n1)
-        		quality=$(printf "Audio 144p 240p 360p 480p 720P 1080p 1440P 2160p" | awk -F"$max_quality""p" '{print $1 FS}' | sed "s/ /\n/g" | eval "$menu_command" | sed "s/p//g")
-			[ $quality = "Audio"  ] && YTFZF_PREF="bestaudio/best" || YTFZF_PREF="bestvideo[height=?$quality][fps<=?30][vcodec!=?vp9]+bestaudio/best"
-			[ -z "$YTFZF_PREF"  ] && exit;
-
+		        local max_quality=$(youtube-dl -F "$(printf "$selected_urls")" | awk '{print $3}' | cut -dx -f2 | sort -n | tail -n1)
+        		local quality=$(printf "Audio 144p 240p 360p 480p 720P 1080p 1440P 2160p" | awk -F"$max_quality""p" '{print $1 FS}' | sed "s/ /\n/g" | eval "$menu_command" | sed "s/p//g")
+	    		[ -z "$quality"  ] && exit;
+	                [ $quality = "Audio"  ] && YTFZF_PREF="bestaudio/best" || YTFZF_PREF="bestvideo[height=?$quality][fps<=?30][vcodec!=?vp9]+bestaudio/best"
+	
 	fi
 }
 

--- a/ytfzf
+++ b/ytfzf
@@ -724,9 +724,11 @@ print_data () {
 get_video_format () {
 	# select format if flag given
 	if [ $show_format -eq 1 ]; then 
-		YTFZF_PREF="$(youtube-dl -F "$(printf "$selected_urls" | sed 1q)" | sed '1,3d' | sed '1!G; h; $!d' |\
-		eval "$menu_command" | sed -E 's/^([^ ]*) .*/\1/')"
-		[ -z "$YTFZF_PREF"  ] && exit;
+		        max_quality=$(youtube-dl -F "$(printf "$selected_urls")" | awk '{print $3}' | cut -dx -f2 | sort -n | tail -n1)
+        		quality=$(printf "Audio 144p 240p 360p 480p 720P 1080p 1440P 2160p" | awk -F"$max_quality""p" '{print $1 FS}' | sed "s/ /\n/g" | eval "$menu_command" | sed "s/p//g")
+			[ $quality = "Audio"  ] && YTFZF_PREF="bestaudio/best" || YTFZF_PREF="bestvideo[height=?$quality][fps<=?30][vcodec!=?vp9]+bestaudio/best"
+			[ -z "$YTFZF_PREF"  ] && exit;
+
 	fi
 }
 


### PR DESCRIPTION
The format selection menu was too cluttered also the video only options were giving me trouble. So I changed some lines in script for myself then I thought maybe other people are having the same problems therefore I am creating this pull request.
    
Basically it only shows Video resolutions that are available eg. 144p,480p just like in Youtube and with an audio only option . So user can just select the resolution and be done with it.