### PR TITLE
New features: store and show view dates, allow clearing partial history

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -39,11 +39,18 @@ If you wish to find inspiration and see an example you can take a look at the [`
 		ytfzf -H
 		```
 
-	- Clear history
+	- Clear entire history
 
 		```sh
 		ytfzf -x
 		```
+
+    - Clear old history
+
+        ```sh
+        ytfzf --clear-before='2 days ago'
+        ytfzf --clear-before='2021-03-26 12:00'
+        ```
 
 	- History file: `~/.cache/ytfzf/ytfzf_hst`
 

--- a/ytfzf
+++ b/ytfzf
@@ -143,7 +143,8 @@ basic_helpinfo () {
     printf "     --thumbnail-quality=<0,1>              0: low quality (faster), 1: default\n"
     printf "     -D, --ext-menu                         Use external menu(default dmenu) instead of fzf \n";
     printf "     -H, --choose-from-history              Choose from history \n";
-    printf "     -x, --clear-history                    Delete history\n";
+    printf "     -x, --clear-history                    Delete all history\n";
+    printf "     -X, --clear-before=[date]              Delete videos viewed before the provided date or interval\n";
     printf "     -m, --audio-only     <search-query>    Audio only (for music)\n";
     printf "     -d, --download       <search-query>    Download to current directory\n";
     printf "     -f                   <search-query>    Show available formats before proceeding\n";
@@ -809,7 +810,20 @@ get_history () {
 }
 clear_history () {
 	if [ -e "$history_file" ]; then
-		printf "" > "$history_file"
+        newfile=""
+        if [ -n "$1" ]; then
+            echo "Removing videos viewed earlier than $1"
+            cutoff=$(date --date="$1" +%s)
+            while IFS="$(printf '\t')" read -r line; do
+                viewed=$(echo "$line" | cut --fields=7)
+                viewed=$(date --date="${viewed#|}" +%s)
+                if [ "$viewed" -ge "$cutoff" ]; then
+                    newfile="${newfile}${line}
+"
+                fi
+            done < "$history_file"
+        fi
+        printf "%s" "$newfile" > "$history_file"
 		printf "History has been cleared\n"
 	else
 		printf "\033[31mHistory file not found, history not cleared\033[0m\n"
@@ -903,6 +917,8 @@ parse_long_opt () {
 		choose-from-history) parse_opt "H" ;;
 
 		clear-history) parse_opt "x" ;;
+
+        clear-before=*) parse_opt "X" "${opt#*=}" ;;
 
 		search-again|search-again=*) 
 		    [ "$opt" = 'search-again' ] && parse_opt "s" || parse_opt "s" "${opt#*=}"
@@ -1004,6 +1020,8 @@ parse_opt () {
 
 		x)	clear_history && exit ;;
 
+		X)	clear_history "${optarg:-1}" && exit ;;
+
 		a)	auto_select=${optarg:-1} ;;
 
 		A)	select_all=${optarg:-1} ;;
@@ -1040,7 +1058,7 @@ parse_opt () {
 	esac
 }
 
-while getopts "LhDmdfxHaArltSsvNn:U:-:" OPT; do
+while getopts "LhDmdfxX:HaArltSsvNn:U:-:" OPT; do
     parse_opt "$OPT" "$OPTARG"
 done
 shift $((OPTIND-1))

--- a/ytfzf
+++ b/ytfzf
@@ -253,12 +253,15 @@ format_ext_menu () {
 	date_len=$((frac * 3/2 + 100 ))
 	#url space
 	url_len=12
+    #viewed space
+    viewed_len=17
 }
 format_fzf () {
 	dur_len=7
 	view_len=10
 	date_len=14
 	url_len=12
+    viewed_len=17
 
 	#*_len works the same as it does in format_ext_menu
 	#show title, channel
@@ -319,12 +322,13 @@ if ! function_exists 'video_info_text'; then
 		printf "%-${view_len}.${view_len}s\t" "$views"
 		printf "%-${date_len}.${date_len}s\t" "$date"
 		printf "%-${url_len}.${url_len}s\t" "$shorturl"
+        printf "%-${viewed_len}.${viewed_len}s\t" "$viewed"
 		printf "\n"
 	}
 fi
 format_video_data () {
-	local title channel duration views date shorturl IFS="$(printf "\t")"
-	while read -r title channel views duration date shorturl; do
+	local title channel duration views date shorturl viewed IFS="$(printf "\t")"
+	while read -r title channel views duration date shorturl viewed; do
 	    video_info_text
 	done << EOF
 $*
@@ -370,14 +374,15 @@ if ! function_exists 'thumbnail_video_info_text' ; then
 	printf "\n${c_blue}Duration	${c_yellow}%s" "$duration"
 	printf "\n${c_blue}Views	${c_magenta}%s" "$views"
 	printf "\n${c_blue}Date	${c_cyan}%s" "$date"
+    if expr "$viewed" : \\w >/dev/null; then printf "\n${c_blue}Viewed: ${c_cyan}%s" "$viewed"; fi
     }
 fi
 
 preview_img () {
 	local preview_data="$( printf '%s' "$*" | sed "s/ *""$(printf '\t|')""/""$(printf '\t')""/g" )"
 
-	local title channel duration views date shorturl IFS="$(printf "\t")"
-	read -r title channel duration views date shorturl << EOF
+	local title channel duration views date shorturl viewed IFS="$(printf "\t")"
+	read -r title channel duration views date shorturl viewed << EOF
 $preview_data
 EOF
 
@@ -696,7 +701,7 @@ user_selection () {
 
 format_user_selection () {
 	#gets a list of video ids/urls from the selected data
-	local shorturls="$(printf "%s" "$selected_data" | sed -E -n -e "s_.*\|([^|]+) *\$_\1_p")"
+    local shorturls="$(printf "%s" "$selected_data" | cut --fields=6)"
 	[ -z "$shorturls" ] && exit;
 
 	#for each url append the full url to the $urls string
@@ -705,9 +710,10 @@ format_user_selection () {
 	selected_data=""
 	for surl in $shorturls; do
 		[ -z "$surl" ] && continue
+        surl="${surl#|}"
 		selected_urls="$(printf '%s\n%s' "$selected_urls" "https://www.youtube.com/watch?v=$surl")"
 		selected_data="$(printf '%s\n%s' "$selected_data" "$(printf "%s" "$videos_data" | grep -m1 -e "$surl" )")"
-	done 
+	done
 	selected_urls="$( printf "%s" "$selected_urls" | sed 1d )"
 	#sometimes % shows up in selected data, could throw an error if it's an invalid directive
 	selected_data="$( printf "%s" "$selected_data" | sed 1d )"
@@ -764,8 +770,9 @@ delete_thumbnails () {
 }
 #> Save and clean up before script exits
 save_before_exit () {
+    date=$(date '+%F %_H:%_M')
 	[ "$is_url" -eq 1 ] && exit
-	[ "$YTFZF_HIST" -eq 1 ] && printf "%s\n" "$selected_data" >> "$history_file" ;
+    [ "$YTFZF_HIST" -eq 1 ] && printf "%s\t|%s\n" "$selected_data" "$date" >> "$history_file" ;
 	[ "$YTFZF_CUR" -eq 1 ] && printf "" > "$current_file" ;
 }
 


### PR DESCRIPTION
This pull request introduces two features, in two separate commits. There are detailed explanations in each commit message, but in short, the features are:

1. Store view dates in history, show when `-H` is used.
2. Allow removing videos from history that were viewed before the provided date or interval (e.g. '2 days ago') via new option `--clear-before`.

It is my hope that you will at least find the first feature useful for common users. The second feature requires the first, but I'm not sure you'll find it useful enough to include. Personally, I'd like to automate clearing of history (e.g. via a cron job), but still keep a certain amount of recent history. If you feel only the first feature should enter, I'll gladly open a PR purely for it.

These are backwards compatible changes, and I have taken care to make sure all changes are POSIX-compatible. That said, it's entirely possible that I missed something in my tests. Please read the note in the first commit message about terminal widths and let me know if any changes are necessary.

Thanks!