### PR TITLE
Add option to use wget instead of curl in order to bypass YouTube's consent form

### DIFF
--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -127,6 +127,10 @@ fancy_subscriptions_menu=1
 #yt_subs is the same as -S
 scrape="yt_search"
 
+#use wget instead of curl to scrape youtube
+#can be used to bypass youtube's consent form
+use_wget=0
+
 #the filter id that will be used when searching youtube
 #same as --filter-id={filter}
 #to get a filter id go to youtube search for something, choose the filter you want,

--- a/ytfzf
+++ b/ytfzf
@@ -539,14 +539,9 @@ get_yt_json () {
 }
 
 get_yt_html () {
-    link="$1"
-    query="$2"
-
-
-get_yt_html () {
     local link="$1"
     local query="$2"
-	if [ $use_wget -eq 1 ]; then
+	if [ "$use_wget" -eq 1 ]; then
 		printf "%s" "$(
 		wget -O - --no-cookie --quiet \
 	      --header 'authority: www.youtube.com' \
@@ -1038,7 +1033,7 @@ parse_long_opt () {
 
 		notification) parse_opt "N" ;;
 
-		wget) uset_wget=1 ;;
+		wget) use_wget=1 ;;
 
 		version)
 		    printf "\033[1mytfzf:\033[0m %s\n" "$YTFZF_VERSION"
@@ -1123,7 +1118,7 @@ parse_opt () {
 	unset opt optarg
 }
 
-while getopts "LhDmdfxHaArltSsvNn:U:-:" OPT; do
+while getopts "LhDmdfxHaArltSsvNwn:U:-:" OPT; do
     parse_opt "$OPT" "$OPTARG"
 done
 shift $((OPTIND-1))

--- a/ytfzf
+++ b/ytfzf
@@ -104,7 +104,8 @@ sp="${sp-}"
 scrape="${scrape-yt_search}"
 #auto generated caption by youtube with enabled with --subt
 auto_caption=${auto_caption-0}
-
+#whether to use wget instead of cutl in get_yt_html() (same as -w)
+use_wget=${use_wget-0}
 
 #ueberzug related variables
 #the side where thumbnails are shown
@@ -174,6 +175,7 @@ basic_helpinfo () {
     printf "     -D, --ext-menu                         Use external menu(default dmenu) instead of fzf \n";
     printf "     -H, --choose-from-history              Choose from history \n";
     printf "     -x, --clear-history                    Delete history\n";
+    printf "     -w, --wget                             Scrape YouTube with wget instead of curl\n";
     printf "     -m, --audio-only     <search-query>    Audio only (for music)\n";
     printf "     -d, --download       <search-query>    Download to current directory\n";
     printf "     -f                   <search-query>    Show available formats before proceeding\n";
@@ -539,15 +541,30 @@ get_yt_json () {
 get_yt_html () {
     link="$1"
     query="$2"
-    printf "%s" "$(
-	curl "$link" -s \
-	  -G --data-urlencode "search_query=$query" \
-	  -G --data-urlencode "sp=$sp" \
-	  -H 'authority: www.youtube.com' \
-	  -H "user-agent: $useragent" \
-	  -H 'accept-language: en-US,en;q=0.9' \
-	  --compressed
-    )"
+
+
+get_yt_html () {
+    local link="$1"
+    local query="$2"
+	if [ $use_wget -eq 1 ]; then
+		printf "%s" "$(
+		wget -O - --no-cookie --quiet \
+	      --header 'authority: www.youtube.com' \
+	      --header "user-agent: $useragent" \
+	      --header 'accept-language: en-US,en;q=0.9' \
+	      "${link}?search_query=${query}&sp=${sp}" \
+		)"
+	else
+		printf "%s" "$(
+		curl "$link" -s \
+	  	  -G --data-urlencode "search_query=$query" \
+	  	  -G --data-urlencode "sp=$sp" \
+	  	  -H 'authority: www.youtube.com' \
+	  	  -H "user-agent: $useragent" \
+	  	  -H 'accept-language: en-US,en;q=0.9' \
+	  	  --compressed
+		)"
+	fi
     unset link query
 }
 
@@ -578,7 +595,7 @@ scrape_channel () {
 	yt_html="$(get_yt_html "$channel_url")"
 
 	if [ -z "$yt_html" ]; then
-	        print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[0m\n"
+	        print_error "\033[31mERROR[#01]: Couldn't download website. Please check your network and try again.\033[0m\n"
 	        exit 1
 	fi
 
@@ -643,7 +660,7 @@ scrape_yt () {
 
 	yt_html="$(get_yt_html "https://www.youtube.com/results" "$*")"
 	if [ -z "$yt_html" ]; then
-		print_error "\033[31mERROR[#01]: Couldn't curl website. Please check your network and try again.\033[0m\n"
+		print_error "\033[31mERROR[#01]: Couldn't download website. Please check your network and try again.\033[0m\n"
 		exit 1
 	fi
 
@@ -1021,6 +1038,8 @@ parse_long_opt () {
 
 		notification) parse_opt "N" ;;
 
+		wget) uset_wget=1 ;;
+
 		version)
 		    printf "\033[1mytfzf:\033[0m %s\n" "$YTFZF_VERSION"
 		    printf "\033[1myoutube-dl:\033[0m %s\n" "$(youtube-dl --version)"
@@ -1094,6 +1113,8 @@ parse_opt () {
 			;;
 
 		N)	YTFZF_NOTI=1 ;;
+
+		w)	use_wget=1 ;;
 
 		*)
 			usageinfo

--- a/ytfzf
+++ b/ytfzf
@@ -1033,7 +1033,7 @@ parse_long_opt () {
 
 		notification) parse_opt "N" ;;
 
-		wget) use_wget=1 ;;
+		wget) parse_opt "w" ;;
 
 		version)
 		    printf "\033[1mytfzf:\033[0m %s\n" "$YTFZF_VERSION"

--- a/ytfzf
+++ b/ytfzf
@@ -548,7 +548,7 @@ get_yt_html () {
 		  --header "user-agent: $useragent" \
 		  --header 'accept-language: en-US,en;q=0.9' \
 		  "${link}?search_query=${query}&sp=${sp}" \
-		  )"
+		)"
 	else
 		printf "%s" "$(
 		curl "$link" -s \

--- a/ytfzf
+++ b/ytfzf
@@ -544,20 +544,20 @@ get_yt_html () {
 	if [ "$use_wget" -eq 1 ]; then
 		printf "%s" "$(
 		wget -O - --no-cookie --quiet \
-	      --header 'authority: www.youtube.com' \
-	      --header "user-agent: $useragent" \
-	      --header 'accept-language: en-US,en;q=0.9' \
-	      "${link}?search_query=${query}&sp=${sp}" \
-		)"
+		  --header 'authority: www.youtube.com' \
+		  --header "user-agent: $useragent" \
+		  --header 'accept-language: en-US,en;q=0.9' \
+		  "${link}?search_query=${query}&sp=${sp}" \
+		  )"
 	else
 		printf "%s" "$(
 		curl "$link" -s \
-	  	  -G --data-urlencode "search_query=$query" \
-	  	  -G --data-urlencode "sp=$sp" \
-	  	  -H 'authority: www.youtube.com' \
-	  	  -H "user-agent: $useragent" \
-	  	  -H 'accept-language: en-US,en;q=0.9' \
-	  	  --compressed
+		  -G --data-urlencode "search_query=$query" \
+		  -G --data-urlencode "sp=$sp" \
+		  -H 'authority: www.youtube.com' \
+		  -H "user-agent: $useragent" \
+		  -H 'accept-language: en-US,en;q=0.9' \
+		  --compressed
 		)"
 	fi
     unset link query


### PR DESCRIPTION
This patch adds the option to use wget instead of curl in the get_yt_html function. Included are both short and long command line options and the option to set the use_wget variable via conf.sh. The variable defaults to 0, i.e. disabled.

The --no-cookie option of wget allows the user to bypass YouTube's consent form which blocks some users from scraping the site (see #183).