### PR TITLE
Youtube consent bypass

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -512,7 +512,7 @@ get_yt_html () {
 	  -H 'authority: www.youtube.com' \
 	  -H "user-agent: $useragent" \
 	  -H 'accept-language: en-US,en;q=0.9' \
-    -L \
+	  -L \
 	  --compressed
     )"
 }

--- a/ytfzf
+++ b/ytfzf
@@ -512,6 +512,7 @@ get_yt_html () {
 	  -H 'authority: www.youtube.com' \
 	  -H "user-agent: $useragent" \
 	  -H 'accept-language: en-US,en;q=0.9' \
+    -L \
 	  --compressed
     )"
 }


### PR DESCRIPTION
This patch adds the `-L` (Follow redirects) flag to the curl command in `get_video_data()` to *bypass* the Youtube consent page shown in some countries. The issue would occur when trying to scrape data from Youtube.

Tested and seems to work well.

This is a followup to https://github.com/pystardust/ytfzf/pull/187 where it was suggested to try this approach instead of using wget with the `--no-cookie` flag set.

(Also see #183 )
