### PR TITLE
 [FIX} Fixed get_video_format function for 720p videos.

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -764,7 +764,7 @@ get_video_format () {
 	# select format if flag given
 	if [ $show_format -eq 1 ]; then
         max_quality=$(youtube-dl -F "$(printf "$selected_urls")" | awk '{print $4}' | sort -n | tail -n1)
-        quality=$(printf "Audio 144p 240p 360p 480p 720p 1080p 1440P 2160p" | awk -F"$max_quality" '{print $1 FS}' | sed "s/ /\n/g" | eval "$menu_command" | sed "s/p//g")
+        quality=$(printf "Audio 144p 240p 360p 480p 720p 1080p 1440P 2160p 4320p" | awk -F"$max_quality" '{print $1 FS}' | sed "s/ /\n/g" | eval "$menu_command" | sed "s/p//g")
 		[ -z "$quality"  ] && exit;
 	    [ $quality = "Audio"  ] && YTFZF_PREF="bestaudio/best" || YTFZF_PREF="bestvideo[height=?$quality][fps<=?30][vcodec!=?vp9]+bestaudio/best"
 

--- a/ytfzf
+++ b/ytfzf
@@ -763,10 +763,10 @@ print_data () {
 get_video_format () {
 	# select format if flag given
 	if [ $show_format -eq 1 ]; then
-	        max_quality=$(youtube-dl -F "$(printf "$selected_urls")" | awk '{print $3}' | cut -dx -f2 | sort -n | tail -n1)
-		quality=$(printf "Audio 144p 240p 360p 480p 720P 1080p 1440P 2160p" | awk -F"$max_quality""p" '{print $1 FS}' | sed "s/ /\n/g" | eval "$menu_command" | sed "s/p//g")
+        max_quality=$(youtube-dl -F "$(printf "$selected_urls")" | awk '{print $4}' | sort -n | tail -n1)
+        quality=$(printf "Audio 144p 240p 360p 480p 720p 1080p 1440P 2160p" | awk -F"$max_quality" '{print $1 FS}' | sed "s/ /\n/g" | eval "$menu_command" | sed "s/p//g")
 		[ -z "$quality"  ] && exit;
-	        [ $quality = "Audio"  ] && YTFZF_PREF="bestaudio/best" || YTFZF_PREF="bestvideo[height=?$quality][fps<=?30][vcodec!=?vp9]+bestaudio/best"
+	    [ $quality = "Audio"  ] && YTFZF_PREF="bestaudio/best" || YTFZF_PREF="bestvideo[height=?$quality][fps<=?30][vcodec!=?vp9]+bestaudio/best"
 
 	fi
 	unset max_quality quality


### PR DESCRIPTION
I made a mistake in original commit, I left the 'P' for 720p capitalized in quality variable under get_video_format function. That caused bugs when 720p video was being selected. I fixed that and removed unnecessary code.