### PR TITLE
[Fix] Changed the way format menu is implemented.

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -787,8 +787,9 @@ print_data () {
 get_video_format () {
 	# select format if flag given
 	if [ $show_format -eq 1 ]; then
-        max_quality=$(youtube-dl -F "$(printf "$selected_urls")" | awk '{print $4}' | sort -n | tail -n1 | awk -F"p" '{print $1 FS}')
-        quality=$(printf "Audio 144p 240p 360p 480p 720p 1080p 1440p 2160p 4320p" | awk -F"$max_quality" '{print $1 FS}' | sed "s/ /\n/g" | eval "$menu_command" | sed "s/p//g")
+        formats=$(youtube-dl -F "$(printf "$selected_urls")") 
+        line_number=$(printf "$formats" | grep -n '.*extension  resolution.*' | cut -d: -f1)
+        quality=$(printf "$formats \n1 2 xAudio" | awk -v lineno=$line_number 'FNR > lineno {print $3}' | sort -n |  awk -F"x" '{print $2 "p"}' | uniq | sed -e "s/Audiop/Audio/" -e "/^p$/d" | eval "$menu_command" | sed "s/p//g")
 		[ -z "$quality"  ] && exit;
 		[ $quality = "Audio"  ] && YTFZF_PREF= && YTFZF_PLAYER="$YTFZF_AUDIO_PLAYER" || YTFZF_PREF="bestvideo[height=?$quality][vcodec!=?vp9]+bestaudio/best"
 


### PR DESCRIPTION
Menu got messed up if live videos were selected. I made the video quality list completely dependent on the youtube-dl output not just the max quality like before. Formatting is still the same.