### PR TITLE
feat: event functions

### DIFF
--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -353,6 +353,7 @@ on_opt_parse () {
 #this function is called after videos_data has been set and ytfzf knows it's been set
 #$1 will be videos_data
 #$2 will be videos_json
+#$3 will be yt_json
 on_video_data_gotten () {
     return 0
 }
@@ -403,7 +404,7 @@ alphabetical () {
     data_sort_key () {
 	sort_by="${1#|}"
 	#since sort by is the title of the video, not the upload date, use %s
-	printf "%d" "$(date -d "${sort_by}" '+%s')"
+	printf "%s" "$sort_by"
 	unset sort_by
     }
     data_sort_fn () {

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -224,29 +224,27 @@ subscriptions_file=$YTFZF_CONFIG_DIR/subscriptions
 #with video_title, channel, views, duration, date, and shorturl, be sure to use this syntax
     # ${var#|}, that way the extra | at the start will be removed
 send_select_video_notif () {
-         #if show thumbnails and videos_selected is equal to 1   
-         if [ "$show_thumbnails" -eq 1 ] && [ "$videos_selected_count" -eq 1 ]; then
-		#get the thumbnail of the video which was downloaded in $thumb_dir/$video_shorturl
-                 video_thumb="$thumb_dir/${video_shorturl#|}.png"                                                   
-                 #message=$title\nchannel: $channel
-                 message="${video_title#|}\nChannel: ${video_channel#|}"
-         #if more than 1 video is selected
-         elif [ $videos_selected_count -gt 1 ]; then
-		#use the default thbumbnail provided in config, (notify-send wont throw an error if this does not exist)
-                 video_thumb="$config_dir/default_thumb.png"
-                 message="Added $videos_selected_count video to play queue"
-         else
-                 #${var#|} removes the extra | at the start of the text 
-                 message="${video_title#|}\nChannel: ${video_channel#|}"
-                 video_thumb="$config_dir/default_thumb.png"
-         fi
-	 #say downloading instead of currently playing when downloading
-         if [ $is_download -eq 1 ]; then
-             notify-send "Downloading" "$message" -i "$video_thumb"
-         else
-             notify-send "Current playing" "$message" -i "$video_thumb"
-         fi
-	 unset message video_thumb
+	#message=$title\nchannel: $channel        
+        #${var#|} removes the extra | at the start of the text
+        message="${video_title#|}\nChannel: ${video_channel#|}"
+        video_thumb="$config_dir/default_thumb.png"        
+
+        #if more than 1 video selected
+        if [ $videos_selected_count -gt 1 ]; then
+                message="Added $videos_selected_count video to play queue"
+        #if show thumbnails and videos_selected is 1 (it will never be less than 1)         
+        elif [ "$show_thumbnails" -eq 1 ]; then
+                video_thumb="$thumb_dir/${video_shorturl#|}.png"
+        fi
+
+	#if downloading, say Downloading not currently playing
+        if [ $is_download -eq 1 ]; then                             
+            notify-send "Downloading" "$message" -i "$video_thumb"
+        else                                                            
+            notify-send "Current playing" "$message" -i "$video_thumb"
+        fi
+
+        unset message video_thumb
 }
 
 

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -373,32 +373,19 @@ on_exit () {
 # Sort Data #
 #############
 
+#returns the value that it will use to sort
+#parameters
+    #$1: video title
+    #$2: video channel
+    #$3: length of video
+    #$4: view count
+    #$5: upload date
+    #$6: video id
+#be sure to use ${var#|} to get rid of the extra | at the start
 data_sort_key () {
-    #the first argument will be the value given from parse_value_for_key
-    #the second argument wil be the entire line
-    sort_by="$1"
-    line="$2"
-    #the format must be *\t%s\n the first format can be anything
-
+    sort_by="${5#|}"
     #this must return the value to sort by
     printf "%d" "$(date -d "${sort_by}" '+%s')"
-    unset sort_by line
-}
-
-parse_value_for_key () {
-    #get the initial value (each value's first character will be a |, this removes it)
-    #there are a few different values passed into this function
-    #1: the video title
-    #2: the channel
-    #3: the length of the video
-    #4: view count
-    #5: the upload date
-    #6: the video id
-    sort_by=${5#|}
-    #remove non-date part of the upload date
-    sort_by=${sort_by#Streamed}
-    #"return" the value
-    printf "%s" "$sort_by"
     unset sort_by
 }
 
@@ -408,22 +395,15 @@ data_sort_fn () {
     sort -nr
 }
 
-#a sort-name is a function that sets the values of data_sort_key, parse_value_for_key and data_sort_fn
+#a sort-name is a function that sets the values of data_sort_key and data_sort_fn
 #it only needs to set 1 or more of those, however it is better to set all 3 so you know what is happening
 
 alphabetical () {
-    parse_value_for_key () {
-	#to get the title we use the first argument, not the 5th
-	sort_by=${1#|}
-	printf "%s" "$sort_by"
-	unset sort_by
-    }
     data_sort_key () {
-	sort_by="$1"
-	line="$2"
+	sort_by="${1#|}"
 	#since sort by is the title of the video, not the upload date, use %s
 	printf "%d" "$(date -d "${sort_by}" '+%s')"
-	unset sort_by line
+	unset sort_by
     }
     data_sort_fn () {
 	sort

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -380,9 +380,8 @@ data_sort_key () {
     line="$2"
     #the format must be *\t%s\n the first format can be anything
 
-    #the first value to print must be the value to be sorting by
-    #the second value must be the line
-    printf "%d\t%s\n" "$(date -d "${sort_by}" '+%s')" "$line"
+    #this must return the value to sort by
+    printf "%d" "$(date -d "${sort_by}" '+%s')"
     unset sort_by line
 }
 

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -206,24 +206,6 @@ thumb_dir="$cache_dir/thumb"
 #the file where subscriptions are stored
 subscriptions_file=$YTFZF_CONFIG_DIR/subscriptions
 
-#####################
-#     SCRIPTING     #
-#####################
-
-#############
-# Variables #
-#############
-
-#when an invlaid opt is given, eg: --fjiewoapjfewioa it will throw an error and exit when set to 1, otherwise ignore the error
-exit_on_opt_error=1
-
-#when set to 1 it means that you have given data for videos_data and ytfzf will not get the data itself
-custom_videos_data=0
-
-#############
-# Functions #
-#############
-
 #when using the menu, use the text printed in this function to display all the info, $shorturl must be present in order to work
 #available default colors (note: they are be bolded):
     #c_red
@@ -283,6 +265,63 @@ thumbnail_video_info_text () {
          printf "\n${c_blue}Date         ${c_cyan}%s" "$date"
 }
 
+
+#this function is called when a video is selected in the menu to send a notification
+#available variables
+    #$videos_selected_count: the number of videos selected
+    #$video_title
+    #$video_channel
+    #$video_views
+    #$video_duration
+    #$video_date (the upload date)
+    #$video_shorturl (the id of the video)
+
+#with video_title, channel, views, duration, date, and shorturl, be sure to use this syntax
+    # ${var#|}, that way the extra | at the start will be removed
+send_select_video_notif () {
+         #if show thumbnails and videos_selected is equal to 1   
+         if [ "$show_thumbnails" -eq 1 ] && [ "$videos_selected_count" -eq 1 ]; then
+		#get the thumbnail of the video which was downloaded in $thumb_dir/$video_shorturl
+                 video_thumb="$thumb_dir/${video_shorturl#|}.png"                                                   
+                 #message=$title\nchannel: $channel
+                 message="${video_title#|}\nChannel: ${video_channel#|}"
+         #if more than 1 video is selected
+         elif [ $videos_selected_count -gt 1 ]; then
+		#use the default thbumbnail provided in config, (notify-send wont throw an error if this does not exist)
+                 video_thumb="$config_dir/default_thumb.png"
+                 message="Added $videos_selected_count video to play queue"
+         else
+                 #${var#|} removes the extra | at the start of the text 
+                 message="${video_title#|}\nChannel: ${video_channel#|}"
+                 video_thumb="$config_dir/default_thumb.png"
+         fi
+	 #say downloading instead of currently playing when downloading
+         if [ $is_download -eq 1 ]; then
+             notify-send "Downloading" "$message" -i "$video_thumb"
+         else
+             notify-send "Current playing" "$message" -i "$video_thumb"
+         fi
+	 unset message video_thumb
+}
+
+
+#####################
+#     SCRIPTING     #
+#####################
+
+#############
+# Variables #
+#############
+
+#when an invlaid opt is given, eg: --fjiewoapjfewioa it will throw an error and exit when set to 1, otherwise ignore the error
+exit_on_opt_error=1
+
+#when set to 1 it means that you have given data for videos_data and ytfzf will not get the data itself
+custom_videos_data=0
+
+#############
+# Functions #
+#############
 
 #gets called when an opt gets passed
 #$1 will be the opt name

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -210,6 +210,46 @@ thumb_dir="$cache_dir/thumb"
 #the file where subscriptions are stored
 subscriptions_file=$YTFZF_CONFIG_DIR/subscriptions
 
+
+#this function is called when a video is selected in the menu to send a notification
+#available variables
+    #$videos_selected_count: the number of videos selected
+    #$video_title
+    #$video_channel
+    #$video_views
+    #$video_duration
+    #$video_date (the upload date)
+    #$video_shorturl (the id of the video)
+
+#with video_title, channel, views, duration, date, and shorturl, be sure to use this syntax
+    # ${var#|}, that way the extra | at the start will be removed
+send_select_video_notif () {
+         #if show thumbnails and videos_selected is equal to 1   
+         if [ "$show_thumbnails" -eq 1 ] && [ "$videos_selected_count" -eq 1 ]; then
+		#get the thumbnail of the video which was downloaded in $thumb_dir/$video_shorturl
+                 video_thumb="$thumb_dir/${video_shorturl#|}.png"                                                   
+                 #message=$title\nchannel: $channel
+                 message="${video_title#|}\nChannel: ${video_channel#|}"
+         #if more than 1 video is selected
+         elif [ $videos_selected_count -gt 1 ]; then
+		#use the default thbumbnail provided in config, (notify-send wont throw an error if this does not exist)
+                 video_thumb="$config_dir/default_thumb.png"
+                 message="Added $videos_selected_count video to play queue"
+         else
+                 #${var#|} removes the extra | at the start of the text 
+                 message="${video_title#|}\nChannel: ${video_channel#|}"
+                 video_thumb="$config_dir/default_thumb.png"
+         fi
+	 #say downloading instead of currently playing when downloading
+         if [ $is_download -eq 1 ]; then
+             notify-send "Downloading" "$message" -i "$video_thumb"
+         else
+             notify-send "Current playing" "$message" -i "$video_thumb"
+         fi
+	 unset message video_thumb
+}
+
+
 ###################
 #  VIDEO DISPLAY  #
 ###################
@@ -274,45 +314,6 @@ thumbnail_video_info_text () {
 }
 
 
-#this function is called when a video is selected in the menu to send a notification
-#available variables
-    #$videos_selected_count: the number of videos selected
-    #$video_title
-    #$video_channel
-    #$video_views
-    #$video_duration
-    #$video_date (the upload date)
-    #$video_shorturl (the id of the video)
-
-#with video_title, channel, views, duration, date, and shorturl, be sure to use this syntax
-    # ${var#|}, that way the extra | at the start will be removed
-send_select_video_notif () {
-         #if show thumbnails and videos_selected is equal to 1   
-         if [ "$show_thumbnails" -eq 1 ] && [ "$videos_selected_count" -eq 1 ]; then
-		#get the thumbnail of the video which was downloaded in $thumb_dir/$video_shorturl
-                 video_thumb="$thumb_dir/${video_shorturl#|}.png"                                                   
-                 #message=$title\nchannel: $channel
-                 message="${video_title#|}\nChannel: ${video_channel#|}"
-         #if more than 1 video is selected
-         elif [ $videos_selected_count -gt 1 ]; then
-		#use the default thbumbnail provided in config, (notify-send wont throw an error if this does not exist)
-                 video_thumb="$config_dir/default_thumb.png"
-                 message="Added $videos_selected_count video to play queue"
-         else
-                 #${var#|} removes the extra | at the start of the text 
-                 message="${video_title#|}\nChannel: ${video_channel#|}"
-                 video_thumb="$config_dir/default_thumb.png"
-         fi
-	 #say downloading instead of currently playing when downloading
-         if [ $is_download -eq 1 ]; then
-             notify-send "Downloading" "$message" -i "$video_thumb"
-         else
-             notify-send "Current playing" "$message" -i "$video_thumb"
-         fi
-	 unset message video_thumb
-}
-
-
 #####################
 #     SCRIPTING     #
 #####################
@@ -321,7 +322,7 @@ send_select_video_notif () {
 # Variables #
 #############
 
-#when an invlaid opt is given, eg: --fjiewoapjfewioa it will throw an error and exit when set to 1, otherwise ignore the error
+#when an invlaid opt is given, eg: --this-is-not-an-option it will throw an error and exit when set to 1, otherwise ignore the error
 exit_on_opt_error=1
 
 #when set to 1 it means that you have given data for videos_data and ytfzf will not get the data itself
@@ -396,7 +397,7 @@ data_sort_fn () {
 }
 
 #a sort-name is a function that sets the values of data_sort_key and data_sort_fn
-#it only needs to set 1 or more of those, however it is better to set all 3 so you know what is happening
+#it is only necessary to set one of these functions, however it is a good idea to set both for clarity and to be sure it works as intended
 
 alphabetical () {
     data_sort_key () {

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -386,6 +386,7 @@ on_exit () {
 #be sure to use ${var#|} to get rid of the extra | at the start
 data_sort_key () {
     sort_by="${5#|}"
+    sort_bey="${sort_by#Streamed}"
     #this must return the value to sort by
     printf "%d" "$(date -d "${sort_by}" '+%s')"
     unset sort_by

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -325,9 +325,6 @@ thumbnail_video_info_text () {
 #when an invlaid opt is given, eg: --this-is-not-an-option it will throw an error and exit when set to 1, otherwise ignore the error
 exit_on_opt_error=1
 
-#when set to 1 it means that you have given data for videos_data and ytfzf will not get the data itself
-custom_videos_data=0
-
 #############
 # Functions #
 #############

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -10,6 +10,9 @@
 #  ENV VARIABLES  #
 ###################
 
+#this variable should be set somewhere other than here or it will not work
+YTFZF_CONFIG_DIR=$HOME/.config/ytfzf
+
 #each variable below can be set here, or using export
 #when setting them through export, use the variable in parentheses instead
 #variables set through export will override the ones set here
@@ -200,6 +203,27 @@ current_file="$cache_dir/ytfzf_cur"
 #the folder where thumbnails are cached
 thumb_dir="$cache_dir/thumb"
 
+#the file where subscriptions are stored
+subscriptions_file=$YTFZF_CONFIG_DIR/subscriptions
+
+#####################
+#     SCRIPTING     #
+#####################
+
+#############
+# Variables #
+#############
+
+#when an invlaid opt is given, eg: --fjiewoapjfewioa it will throw an error and exit when set to 1, otherwise ignore the error
+exit_on_opt_error=1
+
+#when set to 1 it means that you have given data for videos_data and ytfzf will not get the data itself
+custom_videos_data=0
+
+#############
+# Functions #
+#############
+
 #when using the menu, use the text printed in this function to display all the info, $shorturl must be present in order to work
 #available default colors (note: they are be bolded):
     #c_red
@@ -274,5 +298,26 @@ thumbnail_video_info_text () {
     #$1 will be -
     #$2 will be link-count=2
 on_opt_parse () {
+    return 0
+}
+
+
+#this function is called after videos_data has been set and ytfzf knows it's been set
+#$1 will be videos_data
+#$2 will be videos_json
+on_video_data_gotten () {
+    return 0
+}
+
+
+#this function is called after the search query is gotten, including the initial search used in the command
+    #eg: ytfzf search query
+#$1 will be the search query
+on_get_search () {
+    return 0
+}
+
+#this function will be called when all instances of ytfzf are closed, and the last one is closed
+on_exit () {
     return 0
 }

--- a/ytfzf
+++ b/ytfzf
@@ -880,9 +880,9 @@ session_is_running () {
 	[ -d /proc/"$pid" ] && session_count=$(( session_count + 1 ))
     done < "$pid_file"
     if [ $session_count -eq 1 ]; then
-	return 0
-    else 
 	return 1
+    else 
+	return 0
     fi
 }
 #> removes tmp files and clutter
@@ -895,7 +895,6 @@ clean_up () {
 }
 #> Saves data before exiting
 save_before_exit () {
-	clean_up
 	[ $is_url -eq 1 ] && exit
 	[ $enable_hist -eq 1 ] && printf "%s\n" "$selected_data" >> "$history_file" ;
 	[ $enable_cur -eq 1 ] && printf "" > "$current_file" ;

--- a/ytfzf
+++ b/ytfzf
@@ -1016,7 +1016,6 @@ sort_video_data_fn () {
 	while IFS= read -r line
 	do
 		IFS="$tab_space"
-		set -- $line
 		#run the key function to get the value to sort by
 		printf "%s\t%s\n" "$(data_sort_key $line)" "$line"
 	done | data_sort_fn | cut -f2-

--- a/ytfzf
+++ b/ytfzf
@@ -77,6 +77,8 @@ search_prompt=${search_prompt-Search Youtube: }
 useragent=${useragent-'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36'}
 #whether or not to show errors when an invalid option is passed
 exit_on_opt_error=${exit_on_opt_error-1}
+#whether or not you provided videos_data
+custom_videos_data=0
 
 #Opt variables (can also be set in config)
 #use $YTFZF_EXT_MENU (same as -D)
@@ -567,7 +569,7 @@ get_video_data () {
 	# outputs tab and pipe separated fields: title, channel, view count, video length, video upload date, and the video id/url
 	# from the videos_json
 	printf "%s" "$*" |\
-		jq -r '.[]| "\(.title)'"$tab_space"'|\(.channel)'"$tab_space"'|\(.views)'"$tab_space"'|\(.duration)'"$tab_space"'|\(.date)'"$tab_space"'|\(.videoID)"'
+	    jq -r '.[]| "\(.title)'"$tab_space"'|\(.channel)'"$tab_space"'|\(.views)'"$tab_space"'|\(.duration)'"$tab_space"'|\(.date)'"$tab_space"'|\(.videoID)"'
 }
 
 scrape_channel () {
@@ -620,7 +622,8 @@ scrape_channel () {
 	]')
 
 	videos_json=$(printf "%s" "$videos_json" | jq '.[0:'$sub_link_count']')
-	videos_data=$(get_video_data "$videos_json")
+	[ $custom_videos_data -eq 1 ] && videos_data=$(get_video_data "$videos_json")
+	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json"
 
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "${c_yellow}No results found. Make sure the link ($channel_url) is correct.${c_reset}\n(if this chnanel has not uploaded videos this warning may appear)\n"; exit 1;}
@@ -693,9 +696,10 @@ scrape_yt () {
 		}
 	]')
 
-	videos_data=$(get_video_data "$videos_json")
+	[ $custom_videos_data -eq 1 ] && videos_data=$(get_video_data "$videos_json")
 	#if there aren't videos
 	[ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
+	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json"
 
 	[ "$sort_videos_data" -eq 1 ] && videos_data=$(printf "%s" "$videos_data" | sort_video_data_date)
 
@@ -723,6 +727,7 @@ get_search_query () {
 		fi
 		[ -z "$search_query" ] && exit 0
 	fi
+	function_exists "on_get_search" && on_get_search "$search_query"
 }
 #> To select videos from videos_data
 user_selection () {
@@ -930,7 +935,11 @@ send_notify () {
 		message=$(printf "$video_name\nChannel: $video_channel")
 		video_thumb="$config_dir/default_thumb.png"
 	fi
-	notify-send "Current playing" "$message" -i "$video_thumb"
+	if [ $is_download -eq 1 ]; then
+	    notify-send "Downloading..." "$message" -i "$video_thumb"
+	else
+	    notify-send "Current playing" "$message" -i "$video_thumb"
+	fi
 	unset number_video video_name video_channel message video_thumb
 }
 
@@ -1242,6 +1251,7 @@ esac
 
 
 while true; do
+	custom_videos_data=0
 	user_selection
 	format_user_selection
 	print_data

--- a/ytfzf
+++ b/ytfzf
@@ -627,6 +627,7 @@ scrape_channel () {
 	]')
 
 	videos_json=$(printf "%s" "$videos_json" | jq '.[0:'$sub_link_count']')
+	#checks if it's empty in case it was defined in a config function eg: on_get_search
 	[ -z "$videos_data" ] && videos_data=$(get_video_data "$videos_json")
 	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json" "$yt_json"
 
@@ -704,6 +705,7 @@ scrape_yt () {
 		}
 	]')
 
+	#checks if it's empty in case it was defined in a config function eg: on_get_search
 	[ -z "$videos_data" ] && videos_data=$(get_video_data "$videos_json")
 	#if there aren't videos
 	if [ -z "$videos_data" ]; then
@@ -1275,8 +1277,9 @@ check_if_url "${search_query:=$*}"
 #format the menu screen
 format_menu
 
-[ -n "$sort_name" ] && $sort_name
-unset sort_name
+#if sort_name is define it will define data_sort_key and data_sort_fn
+#otherwise nothing will happen
+$sort_name
 
 case $scrape in
 	"trending")

--- a/ytfzf
+++ b/ytfzf
@@ -79,8 +79,6 @@ useragent=${useragent-'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML
 #> config scripting settings
 #whether or not to show errors when an invalid option is passed
 exit_on_opt_error=${exit_on_opt_error-1}
-#whether or not you provided videos_data
-custom_videos_data=0
 
 #Opt variables (can also be set in config)
 #use $YTFZF_EXT_MENU (same as -D)
@@ -629,7 +627,7 @@ scrape_channel () {
 	]')
 
 	videos_json=$(printf "%s" "$videos_json" | jq '.[0:'$sub_link_count']')
-	[ $custom_videos_data -eq 0 ] && videos_data=$(get_video_data "$videos_json")
+	[ -z "$videos_data" ] && videos_data=$(get_video_data "$videos_json")
 	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json" "$yt_json"
 
 	#if there aren't videos
@@ -706,13 +704,13 @@ scrape_yt () {
 		}
 	]')
 
-	[ $custom_videos_data -eq 0 ] && videos_data=$(get_video_data "$videos_json")
+	[ -z "$videos_data" ] && videos_data=$(get_video_data "$videos_json")
 	#if there aren't videos
 	if [ -z "$videos_data" ]; then
 	    printf "No results found. Try different keywords.\n"
 	    exit 1
 	fi
-	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json"
+	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json" "$yt_json"
 
 	[ "$sort_videos_data" -eq 1 ] && videos_data=$(printf "%s" "$videos_data" | sort_video_data_fn)
 
@@ -1303,7 +1301,6 @@ esac
 
 
 while true; do
-	custom_videos_data=0
 	user_selection
 	format_user_selection
 	print_data
@@ -1320,7 +1317,7 @@ while true; do
 
 	#if -s was specified make another search query
 	if [ $search_again -eq 1 ]; then
-		search_query=
+		unset videos_data search_query
         	get_search_query
 		scrape_yt "$search_query"
 	fi

--- a/ytfzf
+++ b/ytfzf
@@ -940,26 +940,37 @@ clear_history () {
 	fi
 }
 
-send_notify () {
-	number_video=$(printf "%s\n" "$*" | wc -l)
-	video_name=$(printf "%s" "$*" | cut -d'|' -f1 )
-	video_channel=$(printf "%s" "$*" | cut -d'|' -f2)
-	if [ "$show_thumbnails" -eq 1 ] && [ "$number_video" -eq 1 ]; then
-		video_thumb="$thumb_dir/$(printf "%s" "$selected_data" | cut -d'|' -f6).png"
-		message=$(printf "$video_name\nChannel: $video_channel")
-	elif [ $number_video -gt 1 ]; then
+! function_exists "send_select_video_notif" && send_select_video_notif () {
+	#if show thumbnails and videos_selected is equal to 1
+	if [ "$show_thumbnails" -eq 1 ] && [ "$videos_selected_count" -eq 1 ]; then
+		video_thumb="$thumb_dir/${video_shorturl#|}.png"
+		#message=$title\nchannel: $channel
+		message="${video_title#|}\nChannel: ${video_channel#|}"
+	#if more than 1 video is selected
+	elif [ $videos_selected_count -gt 1 ]; then
 		video_thumb="$config_dir/default_thumb.png"
-		message="Added $number_video video to play queue"
+		message="Added $videos_selected_count video to play queue"
 	else
-		message=$(printf "$video_name\nChannel: $video_channel")
+		#${var#|} removes the extra | at the start of the text
+		message="${video_title#|}\nChannel: ${video_channel#|}"
 		video_thumb="$config_dir/default_thumb.png"
 	fi
 	if [ $is_download -eq 1 ]; then
-	    notify-send "Downloading..." "$message" -i "$video_thumb"
+	    notify-send "Downloading" "$message" -i "$video_thumb"
 	else
 	    notify-send "Current playing" "$message" -i "$video_thumb"
 	fi
-	unset number_video video_name video_channel message video_thumb
+	unset message video_thumb
+}
+
+send_notify () {
+	videos_selected_count=$(printf "%s\n" "$*" | wc -l)
+	while IFS=$tab_space read -r video_title video_channel video_views video_duration video_date video_shorturl; do
+	    send_select_video_notif
+	done << EOF
+$*
+EOF
+	unset videos_selected_count video_title video_channel video_views video_duration video_date video_shorturl
 }
 
 update_ytfzf () {

--- a/ytfzf
+++ b/ytfzf
@@ -75,6 +75,8 @@ pid_file="$cache_dir/.pid"
 search_prompt=${search_prompt-Search Youtube: }
 #used when getting the html from youtube
 useragent=${useragent-'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36'}
+
+#> config scripting settings
 #whether or not to show errors when an invalid option is passed
 exit_on_opt_error=${exit_on_opt_error-1}
 #whether or not you provided videos_data
@@ -622,11 +624,15 @@ scrape_channel () {
 	]')
 
 	videos_json=$(printf "%s" "$videos_json" | jq '.[0:'$sub_link_count']')
-	[ $custom_videos_data -eq 1 ] && videos_data=$(get_video_data "$videos_json")
+	[ $custom_videos_data -eq 0 ] && videos_data=$(get_video_data "$videos_json")
 	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json"
 
 	#if there aren't videos
-	[ -z "$videos_data" ] &&  { printf "${c_yellow}No results found. Make sure the link ($channel_url) is correct.${c_reset}\n(if this chnanel has not uploaded videos this warning may appear)\n"; exit 1;}
+	if [ -z "$videos_data" ]; then
+	    printf "${c_yellow}No results found. Make sure the link ($channel_url) is correct.${c_reset}\n(if this chnanel has not uploaded videos this warning may appear)\n"
+	    save_before_exit
+	    exit 1
+	fi
 	if [ $fancy_subscriptions_menu -eq 1 ]; then
 		printf "             -------%s-------\t\n%s\n" "$channel_name" "$videos_data" >> "$tmp_video_data_file"
 	else
@@ -696,9 +702,13 @@ scrape_yt () {
 		}
 	]')
 
-	[ $custom_videos_data -eq 1 ] && videos_data=$(get_video_data "$videos_json")
+	[ $custom_videos_data -eq 0 ] && videos_data=$(get_video_data "$videos_json")
 	#if there aren't videos
-	[ -z "$videos_data" ] &&  { printf "No results found. Try different keywords.\n"; exit 1;}
+	if [ -z "$videos_data" ]; then
+	    printf "No results found. Try different keywords.\n"
+	    save_before_exit
+	    exit 1
+	fi
 	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json"
 
 	[ "$sort_videos_data" -eq 1 ] && videos_data=$(printf "%s" "$videos_data" | sort_video_data_date)
@@ -725,7 +735,7 @@ get_search_query () {
 			printf "$search_prompt"
 			read -r search_query
 		fi
-		[ -z "$search_query" ] && exit 0
+		[ -z "$search_query" ] && clean_up && exit 0
 	fi
 	function_exists "on_get_search" && on_get_search "$search_query"
 }
@@ -755,7 +765,7 @@ user_selection () {
 		selected_data=$( title_len=200 video_menu "$videos_data" )
 		stop_ueberzug
 		# Deletes thumbnails if no video is selected
-		[ -z "$selected_data" ] && delete_thumbnails
+		[ -z "$selected_data" ] && clean_up
 	#show regular menu
 	else
 		selected_data=$( video_menu "$videos_data" )
@@ -858,20 +868,29 @@ play_url () {
 
 	unset player_urls
 }
-#> Checks if other sessions are running, if not then deletes thumbnails
-delete_thumbnails () {
-	session_count=0
-	while read -r pid; do
-		[ -d /proc/"$pid" ] && session_count=$(( session_count + 1 ))
-	done < "$pid_file"
-	if [ $session_count -eq 1 ] ; then
+#> Checks if sessions are running
+session_is_running () {
+    session_count=0
+    while read -r pid; do
+	[ -d /proc/"$pid" ] && session_count=$(( session_count + 1 ))
+    done < "$pid_file"
+    if [ $session_count -eq 1 ]; then
+	return 0
+    else 
+	return 1
+    fi
+}
+#> removes tmp files and clutter
+clean_up () {
+	if ! session_is_running ; then
 		[ -d "$thumb_dir" ] && rm -r "$thumb_dir"
 		printf "" > "$pid_file"
+		function_exists "on_exit" && on_exit
 	fi
-	unset session_count
 }
-#> Save and clean up before script exits
+#> Saves data before exiting
 save_before_exit () {
+	clean_up
 	[ $is_url -eq 1 ] && exit
 	[ $enable_hist -eq 1 ] && printf "%s\n" "$selected_data" >> "$history_file" ;
 	[ $enable_cur -eq 1 ] && printf "" > "$current_file" ;
@@ -1262,7 +1281,7 @@ while true; do
 
 	#if looping and searching_again arent on then exit
 	if [ $enable_loop -eq 0 ] && [ $search_again -eq 0 ] ; then
-		delete_thumbnails
+		clean_up
 		exit
 	fi
 

--- a/ytfzf
+++ b/ytfzf
@@ -635,7 +635,7 @@ scrape_channel () {
 	#if there aren't videos
 	if [ -z "$videos_data" ]; then
 	    printf "${c_yellow}No results found. Make sure the link ($channel_url) is correct.${c_reset}\n(if this chnanel has not uploaded videos this warning may appear)\n"
-	    save_before_exit
+	    clean_up
 	    exit 1
 	fi
 	if [ $fancy_subscriptions_menu -eq 1 ]; then
@@ -711,7 +711,7 @@ scrape_yt () {
 	#if there aren't videos
 	if [ -z "$videos_data" ]; then
 	    printf "No results found. Try different keywords.\n"
-	    save_before_exit
+	    clean_up
 	    exit 1
 	fi
 	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json"

--- a/ytfzf
+++ b/ytfzf
@@ -630,7 +630,7 @@ scrape_channel () {
 
 	videos_json=$(printf "%s" "$videos_json" | jq '.[0:'$sub_link_count']')
 	[ $custom_videos_data -eq 0 ] && videos_data=$(get_video_data "$videos_json")
-	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json"
+	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json" "$yt_json"
 
 	#if there aren't videos
 	if [ -z "$videos_data" ]; then

--- a/ytfzf
+++ b/ytfzf
@@ -999,6 +999,7 @@ update_ytfzf () {
 if ! function_exists "data_sort_key"; then
     data_sort_key () {
 	sort_by="${5#|}"
+	sort_by="${sort_by#Streamed}"
 	#print the data that should be sorted by
 	printf "%d" "$(date -d "${sort_by}" '+%s')"
 	unset sort_by

--- a/ytfzf
+++ b/ytfzf
@@ -635,7 +635,6 @@ scrape_channel () {
 	#if there aren't videos
 	if [ -z "$videos_data" ]; then
 	    printf "${c_yellow}No results found. Make sure the link ($channel_url) is correct.${c_reset}\n(if this chnanel has not uploaded videos this warning may appear)\n"
-	    clean_up
 	    exit 1
 	fi
 	if [ $fancy_subscriptions_menu -eq 1 ]; then
@@ -711,7 +710,6 @@ scrape_yt () {
 	#if there aren't videos
 	if [ -z "$videos_data" ]; then
 	    printf "No results found. Try different keywords.\n"
-	    clean_up
 	    exit 1
 	fi
 	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json"

--- a/ytfzf
+++ b/ytfzf
@@ -1158,7 +1158,7 @@ parse_opt () {
 			is_non_number "$sort_videos_data" && bad_opt_arg "--sort=" "$sort_videos_data" ;;
 		sort-name)
 			sort_videos_data=1
-			sort_name="${opt#*=}" ;;
+			sort_name="$optarg" ;;
 
 		S)	
 			scrape="yt_subs" ;;
@@ -1292,7 +1292,7 @@ check_if_url "${search_query:=$*}"
 #format the menu screen
 format_menu
 
-[ -n "$sort_name" ] && eval "$sort_name"
+[ -n "$sort_name" ] && $sort_name
 unset sort_name
 
 case $scrape in

--- a/ytfzf
+++ b/ytfzf
@@ -189,7 +189,7 @@ Usage: ytfzf [OPTIONS...] <search-query>;
      --subt                                 Select auto-generated subtitles
      --sort                                 Sorts videos by latest upload date
      --sort-name=         <function>        The function must contain the values of
-                                            data_sort_key, parse_value_for_key, data_sort_fn,
+                                            data_sort_key, data_sort_fn,
 					    see the example sort-name in the example config
 
   Use - instead of <search-query> for stdin
@@ -1001,22 +1001,9 @@ update_ytfzf () {
 #gives a value to sort by (this will give the unix time the video was uploaded)
 if ! function_exists "data_sort_key"; then
     data_sort_key () {
-	sort_by="$1"
-	line="$2"
+	sort_by="${5#|}"
 	#print the data that should be sorted by
 	printf "%d" "$(date -d "${sort_by}" '+%s')"
-	unset sort_by line
-    }
-fi
-#gets the value to be put into data_sort_key
-if ! function_exists "parse_value_for_key"; then
-    parse_value_for_key () {
-	#get the initial value
-	sort_by=${5#|}
-	#remove non-date part
-	sort_by=${sort_by#Streamed}
-	#"return" the value
-	printf "%s" "$sort_by"
 	unset sort_by
     }
 fi
@@ -1031,11 +1018,10 @@ sort_video_data_fn () {
 	do
 		IFS="$tab_space"
 		set -- $line
-		sort_by="$(parse_value_for_key $line)"
 		#run the key function to get the value to sort by
-		printf "%s\t%s\n" "$(data_sort_key "$sort_by" "$line")" "$line"
+		printf "%s\t%s\n" "$(data_sort_key $line)" "$line"
 	done | data_sort_fn | cut -f2-
-	unset IFS line sort_by
+	unset IFS line 
 }
 
 scrape_subscriptions () {

--- a/ytfzf
+++ b/ytfzf
@@ -941,25 +941,26 @@ clear_history () {
 }
 
 ! function_exists "send_select_video_notif" && send_select_video_notif () {
-	#if show thumbnails and videos_selected is equal to 1
-	if [ "$show_thumbnails" -eq 1 ] && [ "$videos_selected_count" -eq 1 ]; then
-		video_thumb="$thumb_dir/${video_shorturl#|}.png"
-		#message=$title\nchannel: $channel
-		message="${video_title#|}\nChannel: ${video_channel#|}"
-	#if more than 1 video is selected
-	elif [ $videos_selected_count -gt 1 ]; then
-		video_thumb="$config_dir/default_thumb.png"
+	#message=$title\nchannel: $channel
+	#${var#|} removes the extra | at the start of the text
+	message="${video_title#|}\nChannel: ${video_channel#|}"
+	video_thumb="$config_dir/default_thumb.png"
+
+	#if more than 1 video selected
+	if [ $videos_selected_count -gt 1 ]; then
 		message="Added $videos_selected_count video to play queue"
-	else
-		#${var#|} removes the extra | at the start of the text
-		message="${video_title#|}\nChannel: ${video_channel#|}"
-		video_thumb="$config_dir/default_thumb.png"
+	#if show thumbnails and videos_selected is 1 (it will never be less than 1)
+	elif [ "$show_thumbnails" -eq 1 ]; then
+		video_thumb="$thumb_dir/${video_shorturl#|}.png"
 	fi
+
+	#if downloading, say Downloading not currently playing
 	if [ $is_download -eq 1 ]; then
 	    notify-send "Downloading" "$message" -i "$video_thumb"
 	else
 	    notify-send "Current playing" "$message" -i "$video_thumb"
 	fi
+
 	unset message video_thumb
 }
 


### PR DESCRIPTION
this pull request adds many event functions that act similarly to on_parse_opt
it also adds customizable sorting methods

## Variables

* `custom_videos_data`
    *  when videos_data is provided in a user defined function this should also be set to 1 so that ytfzf doesn't override videos_data

## Events

#### `send_select_video_notif`
gets called when a video is selected
this function handles sending the notification

**usage**:
* custom notifications

#### `on_video_data_gotten`
gets called after `videos_data` is set in `scrape_yt` and `scrape_channel`
there is no expectation of what this function does,

**parameters**:
1. `videos_data`
2. `videos_json`
3. `yt_json`

**usage**:
* to do stuff with videos_data, eg write it to a file,
* make a custom videos_data menu with videos_json/yt_json

#### `on_get_search`
gets called when the search is gotten
there is no expectation of what this function does

**parameters**:
1. `search_query`

**usage**:
* custom actions when a specific search is given
* logging searches to a file

#### `on_exit`
gets called when the last instance of ytfzf exits
there is no expectation of what this function does
**usage**:
* a goodbye notification,
* cleaning up user created tmp files

## Sorting

allow custom sorting methods through 2 functions
`data_sort_key` and `data_sort_fn`

#### `data_sort_key`
gets called to get the value to sort by and to put in `data_sort_fn`

**parameters**:
1. video_title
2. video_channel
3. video_length
4. video_views
5. video_date
6. video_shorturl

#### `data_sort_fn`
gets called to sort the data

### Sort names
a sort name is a function that defines `data_sort_key` and `data_sort_fn`
eg:
```sh
alpha () {
    data_sort_key () {
        sort_by="${1#|}"
        printf "%s" "$sort_by"
    }
    data_sort_fn () ){
        sort
    }
}
```

to use a sort name, in config define the variable `sort_name=alpha` or with the command `ytfzf --sort-name=alpha`