### PR TITLE
feat: Add search history and a search history menu

### DIFF
--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -113,6 +113,10 @@ selected_sub=""
 #any variables here can be set with options when running the command
 #see ytfzf --help for more info
 
+#enable/disable search history menu
+#same as -q
+enable_search_hist_menu=0
+
 #enable/disable using $external_menu
 #same as -D
 is_ext_menu=0
@@ -265,6 +269,18 @@ exit_on_opt_error=1
 
 #the file for storing watch history
 history_file="$cache_dir/ytfzf_hst"
+
+#enable/disable logging of search history
+enable_search_hist=1
+
+#the file for storing search history
+search_history_file="$cache_dir/ytfzf_search_hst"
+
+#prompt for search history menu
+search_history_prompt="> "
+
+#enable/disable launching menu if search history is empty
+allow_empty_search_hist=0
 
 #the file for writing the menu option that was chosen
 current_file="$cache_dir/ytfzf_cur"

--- a/ytfzf
+++ b/ytfzf
@@ -202,9 +202,8 @@ Usage: ytfzf [OPTIONS...] <search-query>;
      -N, --notification                     Send notification when playing video
      -D, --ext-menu                         Use external menu(default dmenu) instead of fzf
      -H, --choose-from-history              Choose from history
-     -x, --clear-history                    Delete history
+     -x, --clear-history=[watch|search]     Delete history
      -q, --search-history                   Open a fzf menu to choose query from search history
-     -X, --clear-search-history             Delete search history
      -m, --audio-only                       Audio only (for music)
      -d, --download                         Download to current directory
      -f                                     Show available formats before proceeding

--- a/ytfzf
+++ b/ytfzf
@@ -1143,13 +1143,29 @@ get_history () {
 }
 
 clear_history () {
-	if [ -e "$history_file" ]; then
-		: > "$history_file"
-		printf "History has been cleared\n"
-	else
-		printf "\033[31mHistory file not found, history not cleared\033[0m\n" >&2
-		exit 1
-	fi
+    case "$1" in
+        search) h_file="${search_history_file}" ;;
+        watch) h_file="${history_file}" ;;
+        *) h_file="${search_history_file}|${history_file}" ;;
+    esac
+
+    exit_code=0
+    IFS="|"
+    for file in $h_file; do
+        if [ "$file" = "$history_file" ]; then
+            name="History"
+        else
+            name="Search History"
+        fi
+        if [ -e "$file" ]; then
+            : > "$file"
+            printf "%s has been cleared\n" "$name"
+        else
+            printf "\033[31m%s file not found, history not cleared\033[0m\n" "$name" >&2
+            exit_code=1
+        fi
+    done
+    exit $exit_code
 }
 
 get_search_history () {
@@ -1165,16 +1181,6 @@ get_search_history () {
 		exit;
 	fi
 	unset hist_data
-}
-
-clear_search_history () {
-	if [ -e "$search_history_file" ]; then
-		: > "$search_history_file"
-		printf "Search history has been cleared\n"
-	else
-		printf "\033[31mSearch history file not found, search history not cleared\033[0m\n" >&2
-		exit 1
-	fi
 }
 
 set_search_history () {
@@ -1392,12 +1398,9 @@ parse_opt () {
 			scrape="history" ;;
 
 		x|clear-history)
-			clear_history && exit ;;
+			clear_history "${optarg}" && exit ;;
         q|search-history)
             search_history_menu ;;
-		X|clear-search-history)
-			clear_search_history && exit ;;
-
 		a|auto-select)
 			auto_select=${optarg:-1}
 			is_non_number "$auto_select" && bad_opt_arg ;;
@@ -1517,7 +1520,7 @@ parse_opt () {
 }
 
 
-while getopts "LhDmdfxXqHaArltSsvNTPYn:U:-:" OPT; do
+while getopts "LhDmdfxqHaArltSsvNTPYn:U:-:" OPT; do
 	# to parse extra-options in conf.sh
 	# when there is no = in OPTARG and it's a longopt, OPTARG will = OPT
 	if [ "$OPT" = "-" ]; then

--- a/ytfzf
+++ b/ytfzf
@@ -1192,11 +1192,11 @@ search_history_menu () {
 
     choice="$( printf "%s\n" "$search_history" | fzf --print-query --no-multi -d '\t' --with-nth=2.. --expect='alt-enter' )"
 
-    query="$( printf "%s" "$choice" | head -n1 )"
+    query="$( printf "%s" "$choice" | sed -n '1p' )"
     [ -z "$query" ] && exit
 
-    key="$( printf "%s" "$choice" | head -n2 )"
-    search="$( printf "%s" "$choice" | head -n3 )"
+    key="$( printf "%s" "$choice" | sed -n '2p' )"
+    search="$( printf "%s" "$choice" | sed -n '3p' )"
 
     if [ -z "$search" ]; then
         search_query="$query"

--- a/ytfzf
+++ b/ytfzf
@@ -1198,10 +1198,13 @@ search_history_menu () {
     fi
 
     query="$( printf "%s" "$choice" | sed -n '1p' )"
-    [ -z "$query" ] && exit
-
     key="$( printf "%s" "$choice" | sed -n '2p' )"
     search="$( printf "%s" "$choice" | sed -n '3p' )"
+
+    # exit if no selection
+    [ -z "$query" ] && [ -z "$search" ] && exit
+    # exit if alt-enter is pressed with empty query
+    [ -n "$key" ] && [ -z "$query" ] && exit 
 
     if [ -z "$search" ]; then
         search_query="$query"

--- a/ytfzf
+++ b/ytfzf
@@ -1191,7 +1191,6 @@ set_search_history () {
 search_history_menu () {
     ! get_search_history && [ "$allow_empty_search_hist" -eq 0 ] && exit 1
 
-
     if [ "$is_ext_menu" -eq 1 ]; then
     #when using an external menu, the search history will be done there
         choice=$( printf "%s\n" "$search_history" | eval "$external_menu" )
@@ -1199,24 +1198,29 @@ search_history_menu () {
         choice="$( printf "%s\n" "$search_history" | fzf --print-query --no-multi -d '\t' --with-nth=2.. --expect='alt-enter' --bind='tab:replace-query' )"
     fi
 
+    # first line is the fzf query (what the user types in fzf)
+    # second line is the fzf --expect key pressed
+    # third line is the search_history selection made
     query="$( printf "%s" "$choice" | sed -n '1p' )"
     key="$( printf "%s" "$choice" | sed -n '2p' )"
-    search="$( printf "%s" "$choice" | sed -n '3p' )"
+    selection="$( printf "%s" "$choice" | sed -n '3p' )"
 
-    # exit if no selection
-    [ -z "$query" ] && [ -z "$search" ] && exit
-    # exit if alt-enter is pressed with empty query
-    [ -n "$key" ] && [ -z "$query" ] && exit 
-
-    if [ -z "$search" ]; then
+    # if no search history selection has been made
+    # and the user typed a query, use that instead
+    if [ -z "$selection" ]; then
+        # exit if no selection or query
+        [ -z "$query" ] && exit
         search_query="$query"
         return
     fi
 
     case $key in
-        alt-enter) search_query="$query"; return;;
+        alt-enter) # Always use query
+            [ -z "$query" ] && exit
+            search_query="$query"
+            return;;
     esac
-    search_query="$( printf "%s" "$search" | awk -F'\t' '{printf "%s", $NF}' )"
+    search_query="$( printf "%s" "$selection" | awk -F'\t' '{printf "%s", $NF}' )"
 }
 
 ! function_exists "send_select_video_notif" && send_select_video_notif () {

--- a/ytfzf
+++ b/ytfzf
@@ -34,7 +34,7 @@ tmp_video_json_file="/tmp/ytfzf-subjson"
 enable_hist=${YTFZF_HIST-${enable_hist-1}}
 #enable/disable search history
 enable_search_hist=${YTFZF_SEARCH_HIST-${enable_search_hist-1}}
-enable_search_hist_menu=${YTFZF_SEARCH_HIST_MENU-${enable_search_hist_menu-1}}
+enable_search_hist_menu=${YTFZF_SEARCH_HIST_MENU-${enable_search_hist_menu-0}}
 #enable/disable looping
 enable_loop=${YTFZF_LOOP-${enable_loop-0}}
 #enable/disable outputting current track to $current_file

--- a/ytfzf
+++ b/ytfzf
@@ -32,6 +32,9 @@ tmp_video_json_file="/tmp/ytfzf-subjson"
 
 #enable/disable history
 enable_hist=${YTFZF_HIST-${enable_hist-1}}
+#enable/disable search history
+enable_search_hist=${YTFZF_SEARCH_HIST-${enable_search_hist-1}}
+enable_search_hist_menu=${YTFZF_SEARCH_HIST_MENU-${enable_search_hist_menu-1}}
 #enable/disable looping
 enable_loop=${YTFZF_LOOP-${enable_loop-0}}
 #enable/disable outputting current track to $current_file
@@ -69,6 +72,7 @@ enable_fzf_default_opts=${YTFZF_ENABLE_FZF_DEFAULT_OPTS-${enable_fzf_default_opt
 
 #> files and directories
 history_file=${history_file-$cache_dir/ytfzf_hst}
+search_history_file=${search_history_file-$cache_dir/ytfzf_search_hst}
 current_file=${current_file-$cache_dir/ytfzf_cur}
 thumb_dir=${thumb_dir-$cache_dir/thumb}
 #> Stores urls of the video page of channels
@@ -199,6 +203,8 @@ Usage: ytfzf [OPTIONS...] <search-query>;
      -D, --ext-menu                         Use external menu(default dmenu) instead of fzf
      -H, --choose-from-history              Choose from history
      -x, --clear-history                    Delete history
+     -q, --search-history                   Open a fzf menu to choose query from search history
+     -X, --clear-search-history             Delete search history
      -m, --audio-only                       Audio only (for music)
      -d, --download                         Download to current directory
      -f                                     Show available formats before proceeding
@@ -871,12 +877,15 @@ get_search_query () {
 		if [ "$is_ext_menu" -eq 1 ]; then
 			#when using an external menu, the query will be done there
 			search_query=$( : | eval "$external_menu" )
+        elif [ $enable_search_hist_menu -eq 1 ]; then
+            search_history_menu
 		else
 			#otherwise use the search prompt
 			printf "$search_prompt"
 			read -r search_query
 		fi
 		[ -z "$search_query" ] && clean_up && exit 0
+        set_search_history
 	fi
 	function_exists "on_get_search" && on_get_search "$search_query"
 }
@@ -1143,6 +1152,55 @@ clear_history () {
 	fi
 }
 
+get_search_history () {
+	if [ "$enable_search_hist" -eq 1 ]; then
+		[ -e "$search_history_file" ] || touch "$search_history_file"
+		#gets history data in reverse order (makes it most recent to least recent)
+		hist_data=$( sed '1!G; h; $!d' "$search_history_file" )
+		[ -z "$hist_data" ] && printf "Search history is empty!\n" >&2 && return 1;
+		#removes duplicate values from $history_data
+		search_history=$(printf "%s" "$hist_data" | uniq )
+	else
+		printf "Search history is not enabled. Please enable it to use this option (-H).\n";
+		exit;
+	fi
+	unset hist_data
+}
+
+clear_search_history () {
+	if [ -e "$search_history_file" ]; then
+		: > "$search_history_file"
+		printf "Search history has been cleared\n"
+	else
+		printf "\033[31mSearch history file not found, search history not cleared\033[0m\n" >&2
+		exit 1
+	fi
+}
+
+set_search_history () {
+    [ -z $search_query ] && return
+    [ $enable_search_hist -eq 1 ] && printf "%s\t%s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "$search_query" >> "$search_history_file" ;
+}
+
+search_history_menu () {
+    get_search_history
+
+    choice="$( printf "%s\n" "$search_history" | fzf --print-query --no-multi -d '\t' --with-nth=2.. --expect='alt-enter' )"
+    query="$( printf "%s" "$choice" | head -n1 )"
+    key="$( printf "%s" "$choice" | head -n2 )"
+    search="$( printf "%s" "$choice" | head -n3 )"
+
+    if [ -z $search ]; then
+        search_query="$query"
+        return
+    fi
+
+    case $key in
+        alt-enter) search_query="$query"; return;;
+    esac
+    search_query="$( printf "%s" "$search" | awk -F'\t' '{printf "%s", $NF}' )"
+}
+
 ! function_exists "send_select_video_notif" && send_select_video_notif () {
 	#message=$title\nchannel: $channel
 	#${var#|} removes the extra | at the start of the text
@@ -1335,6 +1393,10 @@ parse_opt () {
 
 		x|clear-history)
 			clear_history && exit ;;
+        q|search-history)
+            search_history_menu ;;
+		X|clear-search-history)
+			clear_search_history && exit ;;
 
 		a|auto-select)
 			auto_select=${optarg:-1}
@@ -1455,7 +1517,7 @@ parse_opt () {
 }
 
 
-while getopts "LhDmdfxHaArltSsvNTPYn:U:-:" OPT; do
+while getopts "LhDmdfxXqHaArltSsvNTPYn:U:-:" OPT; do
 	# to parse extra-options in conf.sh
 	# when there is no = in OPTARG and it's a longopt, OPTARG will = OPT
 	if [ "$OPT" = "-" ]; then
@@ -1499,8 +1561,14 @@ elif [ "$*" = "-" ]; then
 	do
 	    search_query="$search_query $line"
 	done
+    set_search_history
 fi
-check_if_url "${search_query:=$*}"
+if [ $enable_search_hist_menu -eq 1 ]; then
+    search_history_menu
+else
+    check_if_url "${search_query:=$*}"
+fi
+set_search_history
 
 # If in auto select mode dont download thumbnails
 [ $auto_select -eq 1 ] || [ $random_select -eq 1 ] && show_thumbnails=0;

--- a/ytfzf
+++ b/ytfzf
@@ -886,8 +886,8 @@ get_search_query () {
 			read -r search_query
 		fi
 		[ -z "$search_query" ] && clean_up && exit 0
-        set_search_history
 	fi
+    set_search_history
 	function_exists "on_get_search" && on_get_search "$search_query"
 }
 #> To select videos from videos_data

--- a/ytfzf
+++ b/ytfzf
@@ -1564,7 +1564,6 @@ elif [ "$*" = "-" ]; then
 	do
 	    search_query="$search_query $line"
 	done
-    set_search_history
 fi
 if [ $enable_search_hist_menu -eq 1 ]; then
     search_history_menu

--- a/ytfzf
+++ b/ytfzf
@@ -1190,7 +1190,7 @@ search_history_menu () {
     key="$( printf "%s" "$choice" | head -n2 )"
     search="$( printf "%s" "$choice" | head -n3 )"
 
-    if [ -z $search ]; then
+    if [ -z "$search" ]; then
         search_query="$query"
         return
     fi

--- a/ytfzf
+++ b/ytfzf
@@ -1184,7 +1184,7 @@ get_search_history () {
 }
 
 set_search_history () {
-    [ -z $search_query ] && return
+    [ -z "$search_query" ] && return
     [ $enable_search_hist -eq 1 ] && printf "%s\t%s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "$search_query" >> "$search_history_file" ;
 }
 

--- a/ytfzf
+++ b/ytfzf
@@ -1190,7 +1190,12 @@ set_search_history () {
 search_history_menu () {
     get_search_history
 
-    choice="$( printf "%s\n" "$search_history" | fzf --print-query --no-multi -d '\t' --with-nth=2.. --expect='alt-enter' --bind='tab:replace-query' )"
+    if [ "$is_ext_menu" -eq 1 ]; then
+    #when using an external menu, the search history will be done there
+        choice=$( printf "%s\n" "$search_history" | eval "$external_menu" )
+    else
+        choice="$( printf "%s\n" "$search_history" | fzf --print-query --no-multi -d '\t' --with-nth=2.. --expect='alt-enter' --bind='tab:replace-query' )"
+    fi
 
     query="$( printf "%s" "$choice" | sed -n '1p' )"
     [ -z "$query" ] && exit

--- a/ytfzf
+++ b/ytfzf
@@ -1177,7 +1177,7 @@ get_search_history () {
 		search_history=$(printf "%s" "$hist_data" | uniq )
 	else
 		printf "Search history is not enabled. Please enable it to use this option (-q).\n";
-		exit;
+		exit 1;
 	fi
 	unset hist_data
 }

--- a/ytfzf
+++ b/ytfzf
@@ -36,6 +36,7 @@ enable_hist=${YTFZF_HIST-${enable_hist-1}}
 enable_search_hist=${YTFZF_SEARCH_HIST-${enable_search_hist-1}}
 enable_search_hist_menu=${YTFZF_SEARCH_HIST_MENU-${enable_search_hist_menu-0}}
 allow_empty_search_hist=${YTFZF_ALLOW_EMPTY_SEARCH_HIST-${allow_empty_search_hist-0}}
+search_history_prompt=${YTFZF_SEARCH_HISTORY_PROMPT-${search_history_prompt-"> "}}
 #enable/disable looping
 enable_loop=${YTFZF_LOOP-${enable_loop-0}}
 #enable/disable outputting current track to $current_file
@@ -1195,7 +1196,7 @@ search_history_menu () {
     #when using an external menu, the search history will be done there
         choice=$( printf "%s\n" "$search_history" | eval "$external_menu" )
     else
-        choice="$( printf "%s\n" "$search_history" | fzf --print-query --no-multi -d '\t' --with-nth=2.. --expect='alt-enter' --bind='tab:replace-query' )"
+        choice="$( printf "%s\n" "$search_history" | fzf --prompt="$search_history_prompt" --print-query --no-multi -d '\t' --with-nth=2.. --expect='alt-enter' --bind='tab:replace-query' )"
     fi
 
     # first line is the fzf query (what the user types in fzf)

--- a/ytfzf
+++ b/ytfzf
@@ -1409,8 +1409,7 @@ parse_opt () {
 
 		x|clear-history)
 			clear_history "${optarg}" && exit ;;
-        q|search-history)
-            search_history_menu ;;
+        q|search-history) enable_search_hist_menu=1 ;;
 		a|auto-select)
 			auto_select=${optarg:-1}
 			is_non_number "$auto_select" && bad_opt_arg ;;

--- a/ytfzf
+++ b/ytfzf
@@ -1192,7 +1192,10 @@ search_history_menu () {
     get_search_history
 
     choice="$( printf "%s\n" "$search_history" | fzf --print-query --no-multi -d '\t' --with-nth=2.. --expect='alt-enter' )"
+
     query="$( printf "%s" "$choice" | head -n1 )"
+    [ -z "$query" ] && exit
+
     key="$( printf "%s" "$choice" | head -n2 )"
     search="$( printf "%s" "$choice" | head -n3 )"
 

--- a/ytfzf
+++ b/ytfzf
@@ -1190,7 +1190,7 @@ set_search_history () {
 search_history_menu () {
     get_search_history
 
-    choice="$( printf "%s\n" "$search_history" | fzf --print-query --no-multi -d '\t' --with-nth=2.. --expect='alt-enter' )"
+    choice="$( printf "%s\n" "$search_history" | fzf --print-query --no-multi -d '\t' --with-nth=2.. --expect='alt-enter' --bind='tab:replace-query' )"
 
     query="$( printf "%s" "$choice" | sed -n '1p' )"
     [ -z "$query" ] && exit

--- a/ytfzf
+++ b/ytfzf
@@ -35,6 +35,7 @@ enable_hist=${YTFZF_HIST-${enable_hist-1}}
 #enable/disable search history
 enable_search_hist=${YTFZF_SEARCH_HIST-${enable_search_hist-1}}
 enable_search_hist_menu=${YTFZF_SEARCH_HIST_MENU-${enable_search_hist_menu-0}}
+allow_empty_search_hist=${YTFZF_ALLOW_EMPTY_SEARCH_HIST-${allow_empty_search_hist-0}}
 #enable/disable looping
 enable_loop=${YTFZF_LOOP-${enable_loop-0}}
 #enable/disable outputting current track to $current_file
@@ -1130,7 +1131,7 @@ get_history () {
 		[ -e "$history_file" ] || touch "$history_file"
 		#gets history data in reverse order (makes it most recent to least recent)
 		hist_data=$( sed '1!G; h; $!d' "$history_file" )
-		[ -z "$hist_data" ] && printf "History is empty!\n" >&2 && exit 1;
+		[ -z "$hist_data" ] && printf "History is empty!\n" >&2 && return 1;
 		#removes duplicate values from $history_data
 		videos_data=$(printf "%s" "$hist_data" | uniq )
 		[ "$sort_videos_data" -eq 1 ] && videos_data="$(printf "%s" "$videos_data"  | sort_video_data_fn)"
@@ -1188,7 +1189,8 @@ set_search_history () {
 }
 
 search_history_menu () {
-    get_search_history
+    ! get_search_history && [ "$allow_empty_search_hist" -eq 0 ] && exit 1
+
 
     if [ "$is_ext_menu" -eq 1 ]; then
     #when using an external menu, the search history will be done there
@@ -1604,7 +1606,7 @@ scrape_fn () {
 		scrape_subscriptions
 		;;
 	"history")
-		get_history
+		! get_history && exit 1
 		;;
 	"url")
 	    get_video_format

--- a/ytfzf
+++ b/ytfzf
@@ -874,11 +874,11 @@ scrape_yt () {
 get_search_query () {
 	#in case no query was provided
 	if [ -z "$search_query" ]; then
-		if [ "$is_ext_menu" -eq 1 ]; then
+        if [ $enable_search_hist_menu -eq 1 ]; then
+            search_history_menu
+		elif [ "$is_ext_menu" -eq 1 ]; then
 			#when using an external menu, the query will be done there
 			search_query=$( : | eval "$external_menu" )
-        elif [ $enable_search_hist_menu -eq 1 ]; then
-            search_history_menu
 		else
 			#otherwise use the search prompt
 			printf "$search_prompt"

--- a/ytfzf
+++ b/ytfzf
@@ -1161,7 +1161,7 @@ get_search_history () {
 		#removes duplicate values from $history_data
 		search_history=$(printf "%s" "$hist_data" | uniq )
 	else
-		printf "Search history is not enabled. Please enable it to use this option (-H).\n";
+		printf "Search history is not enabled. Please enable it to use this option (-q).\n";
 		exit;
 	fi
 	unset hist_data

--- a/ytfzf
+++ b/ytfzf
@@ -1564,11 +1564,10 @@ elif [ "$*" = "-" ]; then
 	do
 	    search_query="$search_query $line"
 	done
-fi
-if [ $enable_search_hist_menu -eq 1 ]; then
-    search_history_menu
-else
+elif [ -n "$*" ]; then
     check_if_url "${search_query:=$*}"
+elif [ $enable_search_hist_menu -eq 1 ]; then
+    search_history_menu
 fi
 set_search_history
 

--- a/ytfzf
+++ b/ytfzf
@@ -1577,10 +1577,7 @@ elif [ "$*" = "-" ]; then
 	done
 elif [ -n "$*" ]; then
     check_if_url "${search_query:=$*}"
-elif [ $enable_search_hist_menu -eq 1 ]; then
-    search_history_menu
 fi
-set_search_history
 
 # If in auto select mode dont download thumbnails
 [ $auto_select -eq 1 ] || [ $random_select -eq 1 ] && show_thumbnails=0;


### PR DESCRIPTION
This adds a new feature to save the search/query history and a corresponding fzf menu to select old searches.

New flags:
- `ytfzf -q` Open search history menu
- `ytfz -X` Clear search history menu

New Options:
- `enable_search_hist=1` Enable search history saving 
- `enable_search_history_menu=1` Auto use the search history menu

The fzf query will be used with `alt-enter` or if no other selection left, so can be used as an alternative to regular search input.

Also works with looping :D