### PR TITLE
fix: Add missing is_download config option

### DIFF
--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -97,9 +97,6 @@ is_audio_only=0
 #(YTFZF_AUDIO_PLAYER)
 audio_player="mpv --no-video"
 
-# this emulates the -d flag if set to 1
-is_download=0
-
 #enable/disable ytfzf's use of your $FZF_DEFAULT_OPTS
 #depending on your fzf settings, this could mess up the formatting of the menu
 #(YTFZF_ENABLE_FZF_DEFAULT_OPTS)

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -116,6 +116,9 @@ selected_sub=""
 #any variables here can be set with options when running the command
 #see ytfzf --help for more info
 
+# this emulates the -d flag if set to 1
+is_download=0
+
 #enable/disable search history menu
 #same as -q
 enable_search_hist_menu=0

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -97,6 +97,9 @@ is_audio_only=0
 #(YTFZF_AUDIO_PLAYER)
 audio_player="mpv --no-video"
 
+# this emulates the -d flag if set to 1
+is_download=0
+
 #enable/disable ytfzf's use of your $FZF_DEFAULT_OPTS
 #depending on your fzf settings, this could mess up the formatting of the menu
 #(YTFZF_ENABLE_FZF_DEFAULT_OPTS)

--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -116,7 +116,8 @@ selected_sub=""
 #any variables here can be set with options when running the command
 #see ytfzf --help for more info
 
-# this emulates the -d flag if set to 1
+#download the video instead of watching/listening
+#same as -d
 is_download=0
 
 #enable/disable search history menu

--- a/ytfzf
+++ b/ytfzf
@@ -140,7 +140,7 @@ auto_caption=${auto_caption-0}
 #only play/download the audio if set to 1
 is_audio_only=${is_audio_only-0}
 #flag for downloading
-is_download=0
+is_download=${is_download-0}
 #the tab for trending, empty is the default page
 trending_tab="${trending_tab-}"
 #the sort name, if exists will be called and it will set functions for sorting


### PR DESCRIPTION
Not sure why this was missing, but this adds the `is_download` config option.