### PR TITLE
Url watch history

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -915,7 +915,7 @@ scrape_url () {
 	    exit 1
 	fi
 
-	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json" "$yt_json"
+	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json" "$url_json"
 
 	[ "$sort_videos_data" -eq 1 ] && videos_data=$(printf "%s" "$videos_data" | sort_video_data_fn)
 

--- a/ytfzf
+++ b/ytfzf
@@ -892,8 +892,6 @@ scrape_url () {
 		print_error "ERROR[#02]: Couldn't find data on site.\n"
 		exit 1
 	fi
-    # printf "%s" "$url_json" | jq
-    # exit
 
 	#gets a list of videos
     videos_json=$(printf "%s" "$url_json" | jq '[{

--- a/ytfzf
+++ b/ytfzf
@@ -919,10 +919,14 @@ scrape_url () {
 
 	[ "$sort_videos_data" -eq 1 ] && videos_data=$(printf "%s\n" "$videos_data" | sort_video_data_fn)
 
+    unset url_json
+}
+
+scrape_url_with_thumb () {
+    scrape_url $*
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 	# wait for thumbnails to download
 	wait
-    unset url_json
 }
 
 ############################

--- a/ytfzf
+++ b/ytfzf
@@ -917,7 +917,7 @@ scrape_url () {
 
 	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json" "$url_json"
 
-	[ "$sort_videos_data" -eq 1 ] && videos_data=$(printf "%s" "$videos_data" | sort_video_data_fn)
+	[ "$sort_videos_data" -eq 1 ] && videos_data=$(printf "%s\n" "$videos_data" | sort_video_data_fn)
 
 	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
 	# wait for thumbnails to download
@@ -1189,7 +1189,7 @@ get_history () {
 		[ -z "$hist_data" ] && printf "History is empty!\n" >&2 && return 1;
 		#removes duplicate values from $history_data
 		videos_data=$(printf "%s" "$hist_data" | uniq )
-		[ "$sort_videos_data" -eq 1 ] && videos_data="$(printf "%s" "$videos_data"  | sort_video_data_fn)"
+		[ "$sort_videos_data" -eq 1 ] && videos_data="$(printf "%s\n" "$videos_data"  | sort_video_data_fn)"
 	else
 		printf "History is not enabled. Please enable it to use this option (-H).\n" >&2;
 		exit 1;

--- a/ytfzf
+++ b/ytfzf
@@ -1664,6 +1664,8 @@ scrape_fn () {
 		scrape_subscriptions
 		;;
 	"history")
+        # Thumbnails are never used with history
+        show_thumbnails=0
 		! get_history && exit 1
 		;;
 	"url")

--- a/ytfzf
+++ b/ytfzf
@@ -1157,7 +1157,7 @@ clean_up () {
 }
 #> Saves data before exiting
 save_before_exit () {
-	[ $is_url -eq 1 ] && exit
+	[ $is_url -eq 1 ] && selected_data="$videos_data"
 	[ $enable_hist -eq 1 ] && printf "%s\n" "$selected_data" >> "$history_file" ;
 	[ $enable_cur -eq 1 ] && : > "$current_file" ;
 }
@@ -1669,7 +1669,9 @@ scrape_fn () {
 		;;
 	"url")
 	    get_video_format
+        scrape_url "$search_query"
 	    play_url
+        save_before_exit
 	    exit
 	    ;;
 	*)

--- a/ytfzf
+++ b/ytfzf
@@ -922,12 +922,6 @@ scrape_url () {
     unset url_json
 }
 
-scrape_url_with_thumb () {
-    scrape_url $*
-	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
-	# wait for thumbnails to download
-	wait
-}
 
 ############################
 #      User selection      #
@@ -1195,11 +1189,6 @@ get_history () {
 		videos_data=$(printf "%s" "$hist_data" | uniq )
 		[ "$sort_videos_data" -eq 1 ] && videos_data="$(printf "%s\n" "$videos_data"  | sort_video_data_fn)"
 
-        if [ $show_thumbnails -eq 1 ]; then
-            # get videos_json for preview_img
-            shorturl="$( printf "%s" "$videos_data" | awk -F"\t|" '{print $6}' | sed 's/^|//' )"
-            scrape_url_with_thumb "$( printf "%s" "${shorturl}" )"
-        fi
 	else
 		printf "History is not enabled. Please enable it to use this option (-H).\n" >&2;
 		exit 1;

--- a/ytfzf
+++ b/ytfzf
@@ -1350,7 +1350,6 @@ if ! function_exists "data_sort_fn"; then
 	sort -nr
     }
 fi
-# TODO: Fix, first line does not get returned
 sort_video_data_fn () {
 	while IFS= read -r line
 	do

--- a/ytfzf
+++ b/ytfzf
@@ -1194,6 +1194,12 @@ get_history () {
 		#removes duplicate values from $history_data
 		videos_data=$(printf "%s" "$hist_data" | uniq )
 		[ "$sort_videos_data" -eq 1 ] && videos_data="$(printf "%s\n" "$videos_data"  | sort_video_data_fn)"
+
+        if [ $show_thumbnails -eq 1 ]; then
+            # get videos_json for preview_img
+            shorturl="$( printf "%s" "$videos_data" | awk -F"\t|" '{print $6}' | sed 's/^|//' )"
+            scrape_url_with_thumb "$( printf "%s" "${shorturl}" )"
+        fi
 	else
 		printf "History is not enabled. Please enable it to use this option (-H).\n" >&2;
 		exit 1;

--- a/ytfzf
+++ b/ytfzf
@@ -878,6 +878,54 @@ scrape_yt () {
 	unset playlist_json yt_json yt_html
 }
 
+scrape_url () {
+	# needs url as $*
+	## Scrape data and store video information in videos_data ( and thumbnails )
+
+	print_info "Scraping url...\n"
+
+    # use youtube-dl to get json
+    url_json=$( youtube-dl -J "$*" )
+
+	#if the data couldn't be found
+	if [ -z "$url_json" ]; then
+		print_error "ERROR[#02]: Couldn't find data on site.\n"
+		exit 1
+	fi
+    # printf "%s" "$url_json" | jq
+    # exit
+
+	#gets a list of videos
+    videos_json=$(printf "%s" "$url_json" | jq '[{
+        title: .title,
+        channel: .channel,
+        duration: .duration,
+        views: .view_count,
+        date: .upload_date,
+        description: .description,
+        videoID: .id,
+        thumbs: .thumbnails[0].url
+    }]')
+
+	export videos_json
+
+	#checks if it's empty in case it was defined in a config function eg: on_get_search
+	[ -z "$videos_data" ] && videos_data=$(get_video_data "$videos_json")
+	#if there aren't videos
+	if [ -z "$videos_data" ]; then
+	    printf "No results found. Try different keywords.\n" >&2
+	    exit 1
+	fi
+
+	function_exists "on_video_data_gotten" && on_video_data_gotten "$videos_data" "$videos_json" "$yt_json"
+
+	[ "$sort_videos_data" -eq 1 ] && videos_data=$(printf "%s" "$videos_data" | sort_video_data_fn)
+
+	[ $show_thumbnails -eq 1 ] && download_thumbnails "$videos_json"
+	# wait for thumbnails to download
+	wait
+    unset url_json
+}
 
 ############################
 #      User selection      #

--- a/ytfzf
+++ b/ytfzf
@@ -885,7 +885,7 @@ scrape_url () {
 	print_info "Scraping url...\n"
 
     # use youtube-dl to get json
-    url_json=$( youtube-dl -J "$*" )
+    url_json=$( youtube-dl -J $* )
 
 	#if the data couldn't be found
 	if [ -z "$url_json" ]; then

--- a/ytfzf
+++ b/ytfzf
@@ -1340,6 +1340,7 @@ if ! function_exists "data_sort_fn"; then
 	sort -nr
     }
 fi
+# TODO: Fix, first line does not get returned
 sort_video_data_fn () {
 	while IFS= read -r line
 	do


### PR DESCRIPTION
This pr adds a scrape function for urls to get their video data and save it to watch history.

I am using `youtube-dl -J` to get the video json, however the data it returns is not in the same format as the other scrapers (e.g. duration in seconds instead of HH:MM:SS), this however does not seem to affect the functionality.

NOTE: everything works when `sort_videos_data` is disabled, however there seems to be a bug in the `sort_video_data_fn` function where the first line does not get returned.
This bug effects the other functions of ytfzf as well, such as the first result of `scrape_yt` gets removed.