### PR TITLE
Add a persistent mode

### DIFF
--- a/docs/conf.sh
+++ b/docs/conf.sh
@@ -272,11 +272,11 @@ sp=""
 ####################
 
 #############
-# Shortcuts #
+# Key Binds #
 #############
 
-#the shortcuts to use in fzf
-#the first 6 are used for
+#the key binds to use in fzf
+#the first 7 are used for
     # printing the urls
     # printing the title
     # openeing selected urls in a browser
@@ -284,20 +284,33 @@ sp=""
     # downloading the video
     # listening to the video
     # search again
+    # detach player
 #in that order, these keys can be changed
-#any keys after will not have default behaviour and the behaviour must be defined in handle_custom_shortcuts
-shortcuts="alt-l,alt-t,alt-o,alt-v,alt-d,alt-m,alt-s,alt-enter"
+#any keys after will not have default behaviour and the behaviour can be defined in handle_custom_key_binds
+#any undefined keys will be used for default selection behaviour
+#
+#Note: some parts of `key_binds` used to be handled by `shortcuts`,
+#which is no longer supported
+key_binds="alt-l,alt-t,alt-o,alt-v,alt-d,alt-m,alt-s,alt-enter,enter,double-click"
+
+#this allows for the use of key_binds without leaving fzf
+#therefore fzf does not have to reload and the selection does not get reset
+#if you do not wish to use this behavior, simply leave this option blank
+persistent_key_binds="enter,alt-enter,alt-v,alt-d,alt-o,double-click"
 
 #some helpful variables to keep in mind:
-    #selected_key: they shortcut pressed
+    #selected_key: they key_bind pressed
     #selected_urls: the selected urls
     #selected_data: the line that was selected
     #play_url: a function that takes a url and plays it (play_url "$url") 
 #the return value matters in this function,
     #returning 0 will continue the program as normal
     #returning 1 will exit the program and will clean up after itself
-    #returning 2 will restart the main loop (this is used for the search_again shortcut)
-handle_custom_shortcuts () {
+    #returning 2 will restart the main loop (this is used for the search_again key_bind)
+# 
+#Note: `handle_custom_key_binds` used to be handled by `handle_custom_shortcuts`,
+#which is no longer supported
+handle_custom_key_binds () {
     return 0
 }
 

--- a/ytfzf
+++ b/ytfzf
@@ -96,6 +96,9 @@ key_binds="${key_binds-alt-l,alt-t,alt-o,alt-v,alt-d,alt-m,alt-s,alt-enter,enter
 # these keys allow the use of key_binds without leaving fzf
 persistent_key_binds="${persistent_key_binds-enter,alt-enter,alt-v,alt-d,alt-o,double-click}"
 
+# Depreciation warning for shortcuts
+[ -n "${shortcuts+shortcuts_is_defined}" ] && printf "\033[33mWarning: shortcuts is defined, use the 'key_binds' variable instead\033[0m\n" >&2
+
 search_prompt=${search_prompt-Search: }
 
 #used when getting the html from youtube

--- a/ytfzf
+++ b/ytfzf
@@ -954,27 +954,30 @@ get_search_query () {
     set_search_history
 	function_exists "on_get_search" && on_get_search "$search_query"
 }
+
+persistent_shortcuts () {
+    binds=
+    # make sure every key code is surrounded by commas
+    shortcuts=",$shortcuts,"
+    IFS=','
+    for key in $persistent_shortcuts; do
+        bind_command=":execute-silent(sh $0 -U \"fzf_bind_command $key \"{+f})"
+        binds="${binds},${key}${bind_command}"
+        # Remove used keys from shortcut
+        shortcuts="$( printf "%s" "$shortcuts" | sed "s/,$key,/,/g" )"
+    done
+    unset IFS
+    shortcuts="${shortcuts%,*}"
+    shortcuts="${shortcuts#*,}"
+}
+
 #> To select videos from videos_data
 user_selection () {
+    # format persistent shortcuts for fzf
+    persistent_shortcuts
+
 	#remove subscription separators
 	videos_data_clean=$(printf "%s" "$videos_data" | sed "/.*$tab_space$/d")
-    
-    ## PERSISTENT SHORTCUTS
-    if [ "$enable_loop" -eq 1 ]; then
-        loop_binds=
-        # make sure every key code is surrounded by commas
-        shortcuts=",$shortcuts,"
-        IFS=','
-        for key in $persistent_shortcuts; do
-            bind_command=":execute-silent(sh $0 -U \"fzf_bind_command $key \"{+f})"
-            loop_binds="${loop_binds},${key}${bind_command}"
-            # Remove used keys from shortcut
-            shortcuts="$( printf "%s" "$shortcuts" | sed "s/,$key,/,/g" )"
-        done
-        unset IFS
-        shortcuts="${shortcuts%,*}"
-        shortcuts="${shortcuts#*,}"
-    fi
 
 	#$selected_data is the video the user picked
 	#picks the first n videos
@@ -994,7 +997,7 @@ user_selection () {
 		[ "$thumb_disp_method" = "ueberzug" ] && start_ueberzug
 		#thumbnails only work in fzf, use fzf
         menu_command="fzf -m --tabstop=1 \
-        --bind 'change:top$loop_binds' --delimiter=\"$tab_space\" \
+        --bind 'change:top$binds' --delimiter=\"$tab_space\" \
 		--nth=1,2 --expect='$shortcuts' $FZF_DEFAULT_OPTS \
         --layout=reverse --preview \"sh $0 -U 'preview_img '{}\" \
         	--preview-window \"$PREVIEW_SIDE:50%:noborder:wrap\""

--- a/ytfzf
+++ b/ytfzf
@@ -472,12 +472,13 @@ start_ueberzug () {
     [ -e $FIFO ] || { mkfifo "$FIFO" || exit 1 ; }
     ueberzug layer --parser json --silent < "$FIFO" &
     exec 3>"$FIFO"
+    ueberzug_pid="$!"
 }
 stop_ueberzug () {
     exec 3>&-
     rm "$FIFO" > /dev/null 2>&1
     # make sure ueberzug is really dead
-    ps aux | grep 'ueberzug' | awk '{print $2}' | sed '1q' | xargs kill
+    kill "$ueberzug_pid"
 }
 
 preview_img () {

--- a/ytfzf
+++ b/ytfzf
@@ -969,7 +969,10 @@ persistent_shortcuts () {
     # Build fzf --bind command
     IFS=','
     for key in $persistent_shortcuts; do
-        bind_command=":execute-silent(sh $0 -U \"fzf_bind_command $key \"{+f})"
+        # not sure why, but this won't work with `execute-silent`
+        # sleep is necessary to give the command enough time to execute before
+        # the fzf tmp file gets removed
+        bind_command=":execute(sh -c \"$0 -U \\\"fzf_bind_command $key {+f}\\\"\" >/dev/null 2>&1 & sleep 0.1)"
         binds="${binds},${key}${bind_command}"
         # Remove used keys from shortcut
         shortcuts="$( printf "%s" "$shortcuts" | sed "s/,$key,/,/g" )"
@@ -1018,7 +1021,7 @@ user_selection () {
 		[ "$thumb_disp_method" = "ueberzug" ] && start_ueberzug
 		#thumbnails only work in fzf, use fzf
         menu_command="fzf -m --tabstop=1 \
-        --bind 'change:top$ignore_binds$binds' --delimiter=\"$tab_space\" \
+        --bind 'change:top"$ignore_binds$binds"' --delimiter=\"$tab_space\" \
 		--nth=1,2 --expect='$shortcuts' $FZF_DEFAULT_OPTS \
         --layout=reverse --preview \"sh $0 -U 'preview_img '{}\" \
         	--preview-window \"$PREVIEW_SIDE:50%:noborder:wrap\""

--- a/ytfzf
+++ b/ytfzf
@@ -969,7 +969,7 @@ user_selection () {
 		#thumbnails only work in fzf, use fzf
 		menu_command="fzf -m --tabstop=1 --bind change:top --delimiter=\"$tab_space\" \
 		--nth=1,2 --expect='$shortcuts' $FZF_DEFAULT_OPTS \
-		--layout=reverse --preview \"sh $0 -U {}\" \
+        --layout=reverse --preview \"sh $0 -U 'preview_img '{}\" \
         	--preview-window \"$PREVIEW_SIDE:50%:noborder:wrap\""
 		selected_data=$( title_len=200 video_menu "$videos_data" )
 		[ "$thumb_disp_method" = "ueberzug" ] && stop_ueberzug
@@ -1430,6 +1430,14 @@ bad_opt_arg () {
 	exit 3
 }
 
+parse_internal_opt (){
+    arg=${*%% *}
+    val=${*#* }
+    case "$arg" in
+        preview_img*) preview_img "$val"; exit;;
+    esac
+}
+
 parse_opt () {
 	#the first arg is the option
 	opt=$1
@@ -1551,8 +1559,8 @@ parse_opt () {
 			link_count="$optarg"
 			is_non_number "$link_count" && bad_opt_arg "$link_count" "-n" ;;
 
-		U) 	preview_img "$optarg"; exit;
-			# This option is reserved for the script, to show image previews
+		U) 	parse_internal_opt "$optarg";
+			# This option is reserved for internal scripts
 			# Not to be used explicitly
 			;;
 

--- a/ytfzf
+++ b/ytfzf
@@ -1512,7 +1512,7 @@ parse_internal_opt (){
     val=${*#* }
     case "$arg" in
         preview_img*) preview_img "$val"; exit;;
-        fzf_bind_command*) fzf_bind_command "$val";
+        fzf_bind_command*) fzf_bind_command "$val";;
     esac
 }
 

--- a/ytfzf
+++ b/ytfzf
@@ -1038,7 +1038,7 @@ fzf_bind_command () {
     args=$*
     selected_data="$( cat "${args#* }" )"
     format_user_selection
-    selected_key=${*%% *}
+    selected_key=${args%% *}
 	handle_key_binds
 	case "$?" in
 	    1)
@@ -1504,8 +1504,9 @@ bad_opt_arg () {
 }
 
 parse_internal_opt (){
-    arg=${*%% *}
-    val=${*#* }
+    arg=$*
+    val=${arg#* }
+    arg=${arg%% *}
     case "$arg" in
         preview_img*) preview_img "$val"; exit;;
         fzf_bind_command*) fzf_bind_command "$val";;

--- a/ytfzf
+++ b/ytfzf
@@ -89,14 +89,12 @@ pid_file="$cache_dir/.pid"
 [ -d "$thumb_dir" ] || mkdir -p "$thumb_dir"
 
 #> config settings
-#list of shortcuts to use in fzf
-#handle_custom_shortcuts will be called if defined (handle_custom_shortcuts can call handle_shortcuts to handle normal shortcuts)
-# These binds are used for standard select function
-select_binds="${select_binds-enter,double-click}"
-# shortcuts are used for alternative functions apart from select
-shortcuts="${shortcuts-alt-l,alt-t,alt-o,alt-v,alt-d,alt-m,alt-s,alt-enter}"
-# these keys allow the use of shortcuts or select binds without leaving fzf
-persistent_shortcuts="${persistent_shortcuts-enter,alt-enter,alt-v,alt-d,alt-o,double-click}"
+#handle_custom_key_binds will be called if defined (handle_custom_key_binds can call handle_key_binds to handle normal key binds)
+# key_binds sets the bindings to use for fzf
+# any undefined binds will be used to select
+key_binds="${key_binds-alt-l,alt-t,alt-o,alt-v,alt-d,alt-m,alt-s,alt-enter,enter,double-click}"
+# these keys allow the use of key_binds without leaving fzf
+persistent_key_binds="${persistent_key_binds-enter,alt-enter,alt-v,alt-d,alt-o,double-click}"
 
 search_prompt=${search_prompt-Search: }
 
@@ -409,7 +407,7 @@ format_menu () {
 	if [ "$is_ext_menu" -eq 0 ]; then
 		#dep_ck fzf here because it is only necessary to use here
 		dep_ck "fzf"
-		menu_command='column -t -s "$tab_space" | fzf -m --bind change:top --tabstop=1 --layout=reverse --delimiter="$tab_space" --nth=1,2 --expect="$shortcuts" $FZF_DEFAULT_OPTS'
+		menu_command='column -t -s "$tab_space" | fzf -m --bind change:top --tabstop=1 --layout=reverse --delimiter="$tab_space" --nth=1,2 --expect="$key_binds" $FZF_DEFAULT_OPTS'
 		format_fzf
 	else
 		# Dmenu doesn't render tabs so removing it
@@ -958,47 +956,46 @@ get_search_query () {
 	function_exists "on_get_search" && on_get_search "$search_query"
 }
 
-persistent_shortcuts () {
+persistent_key_binds () {
     # binds for `fzf --binds`
     binds=
 
     # make sure every key code is surrounded by commas
-    # by default, select_binds are shortcuts unless in persistent_binds
-    shortcuts=",${shortcuts},${select_binds},"
+    key_binds=",${key_binds},"
 
     # Build fzf --bind command
     IFS=','
-    for key in $persistent_shortcuts; do
+    for key in $persistent_key_binds; do
         # not sure why, but this won't work with `execute-silent`
         # sleep is necessary to give the command enough time to execute before
         # the fzf tmp file gets removed
         bind_command=":execute(sh -c \"$0 -U \\\"fzf_bind_command $key {+f}\\\"\" >/dev/null 2>&1 & sleep 0.1)"
         binds="${binds},${key}${bind_command}"
-        # Remove used keys from shortcut
-        shortcuts="$( printf "%s" "$shortcuts" | sed "s/,$key,/,/g" )"
+        # Remove used keys from key_binds
+        key_binds="$( printf "%s" "$key_binds" | sed "s/,$key,/,/g" )"
     done
 
-    # if in neither persistent_bind, shortcut or select_binds, ignore
+    # if in neither persistent_bind nor key_binds ignore
     # if in persistent_bind, always ignore
     ignore_keys="enter,double-click"
     ignore_binds=
     for key in $ignore_keys; do
-        printf "%s%s" "$binds" "$shortcuts" | grep -q ",$key," || \
+        printf "%s%s" "$binds" "$key_binds" | grep -q ",$key," || \
             ignore_binds="${ignore_binds},${key}:ignore"
-        printf "%s" "$shortcuts" | grep -q ",$key," || continue
+        printf "%s" "$key_binds" | grep -q ",$key," || continue
         ignore_binds="${ignore_binds},${key}:ignore"
     done
     unset IFS
 
-    # remove leading and tailing , in shortcuts
-    shortcuts="${shortcuts%,*}"
-    shortcuts="${shortcuts#*,}"
+    # remove leading and tailing , in key_binds
+    key_binds="${key_binds%,*}"
+    key_binds="${key_binds#*,}"
 }
 
 #> To select videos from videos_data
 user_selection () {
-    # format persistent shortcuts for fzf
-    persistent_shortcuts
+    # format persistent key binds for fzf
+    persistent_key_binds
 
 	#remove subscription separators
 	videos_data_clean=$(printf "%s" "$videos_data" | sed "/.*$tab_space$/d")
@@ -1022,7 +1019,7 @@ user_selection () {
 		#thumbnails only work in fzf, use fzf
         menu_command="fzf -m --tabstop=1 \
         --bind 'change:top"$ignore_binds$binds"' --delimiter=\"$tab_space\" \
-		--nth=1,2 --expect='$shortcuts' $FZF_DEFAULT_OPTS \
+		--nth=1,2 --expect='$key_binds' $FZF_DEFAULT_OPTS \
         --layout=reverse --preview \"sh $0 -U 'preview_img '{}\" \
         	--preview-window \"$PREVIEW_SIDE:50%:noborder:wrap\""
 		selected_data=$( title_len=200 video_menu "$videos_data" )
@@ -1041,7 +1038,7 @@ fzf_bind_command () {
     selected_data="$( cat "${args#* }" )"
     format_user_selection
     selected_key=${*%% *}
-	handle_shortcuts
+	handle_key_binds
 	case "$?" in
 	    1)
 		save_before_exit
@@ -1056,39 +1053,37 @@ fzf_bind_command () {
     exit
 }
 
-handle_shortcuts () {
+handle_key_binds () {
     [ -z "$selected_key" ] && return 0
 
-    printf ",%s," "$select_binds" | grep -q ",$selected_key," && return 0
-
-    #creates splits the variable shortcuts by , and assigns a variable to each string
-    #ei: $urls_shortcut will be equal to the first keybind
+    #creates splits the variable key_binds by , and assigns a variable to each string
+    #ei: $urls_bind will be equal to the first keybind
     IFS="," read -r \
-	urls_shortcut title_shortcut open_browser_shortcut watch_shortcut \
-	download_shortcut audio_shortcut search_shortcut detach_shortcut _ <<-EOF
-	$shortcuts
+	urls_bind title_bind open_browser_bind watch_bind \
+	download_bind audio_bind search_bind detach_bind _ <<-EOF
+	$key_binds
 	EOF
 
     case $selected_key in
-	"$urls_shortcut") printf "%s\n" $selected_urls; return 1 ;;
-	"$title_shortcut") 
+	"$urls_bind") printf "%s\n" $selected_urls; return 1 ;;
+	"$title_bind") 
 	    printf "%s\n" "$selected_data" | awk -F "  " '{print $1}'; return 1 ;;
-	"$open_browser_shortcut")
+	"$open_browser_bind")
 	    for url in $selected_urls; do
 		nohup $BROWSER "$url" >/dev/null 2>&1
 	    done
 	    return 1 ;;
-	"$watch_shortcut") is_download=0; is_audio_only=0; return 0;;
-	"$download_shortcut") is_download=1; return 0;;
-	"$audio_shortcut") is_audio_only=1; return 0;;
-	"$detach_shortcut") detach_player=1; return 0;;
-	"$search_shortcut")
+	"$watch_bind") is_download=0; is_audio_only=0; return 0;;
+	"$download_bind") is_download=1; return 0;;
+	"$audio_bind") is_audio_only=1; return 0;;
+	"$detach_bind") detach_player=1; return 0;;
+	"$search_bind")
 	    unset videos_data search_query
 	    [ "$scrape" = "pt_search" ] && scrape_fn || scrape="yt_search" scrape_fn
 	    return 2 ;;
     esac
-    if function_exists "handle_custom_shortcuts"; then
-	handle_custom_shortcuts
+    if function_exists "handle_custom_key_binds"; then
+	handle_custom_key_binds
 	return $?
     fi
     return 0
@@ -1773,8 +1768,8 @@ while true; do
 	user_selection
 	#to renable it for a new search
 	format_user_selection
-	#if handle_shortcuts returns 1, exit
-	handle_shortcuts
+	#if handle_key_binds returns 1, exit
+	handle_key_binds
 	case "$?" in
 	    1)
 		save_before_exit

--- a/ytfzf
+++ b/ytfzf
@@ -982,6 +982,17 @@ user_selection () {
 	unset videos_data_clean
 }
 
+selected_data_from_file () {
+    selected_data="$( cat "$*" )"
+    [ -z "$selected_data" ] && exit
+	format_user_selection
+	get_video_format
+	get_sub_lang
+	play_url
+	save_before_exit
+    exit
+}
+
 handle_shortcuts () {
     [ -z "$selected_key" ] && return 0
     #creates splits the variable shortcuts by , and assigns a variable to each string
@@ -1435,6 +1446,7 @@ parse_internal_opt (){
     val=${*#* }
     case "$arg" in
         preview_img*) preview_img "$val"; exit;;
+        selected_data_from_file*) selected_data_from_file "$val";
     esac
 }
 

--- a/ytfzf
+++ b/ytfzf
@@ -466,10 +466,13 @@ start_ueberzug () {
     [ -e $FIFO ] || { mkfifo "$FIFO" || exit 1 ; }
     ueberzug layer --parser json --silent < "$FIFO" &
     exec 3>"$FIFO"
+    ueberzug_pid="$!"
 }
 stop_ueberzug () {
     exec 3>&-
     rm "$FIFO" > /dev/null 2>&1
+    # make sure ueberzug is really dead
+    /bin/kill $ueberzug_pid
 }
 
 preview_img () {

--- a/ytfzf
+++ b/ytfzf
@@ -98,6 +98,7 @@ persistent_key_binds="${persistent_key_binds-enter,alt-enter,alt-v,alt-d,alt-o,d
 
 # Depreciation warning for shortcuts
 [ -n "${shortcuts+shortcuts_is_defined}" ] && printf "\033[33mWarning: shortcuts is defined, use the 'key_binds' variable instead\033[0m\n" >&2
+command -v "handle_custom_shortcuts" > /dev/null 2>&1 && printf "\033[33mWarning: handle_custom_shortcuts is not supported, rename it to handle_custom_key_binds\033[0m\n" >&2
 
 search_prompt=${search_prompt-Search: }
 

--- a/ytfzf
+++ b/ytfzf
@@ -468,13 +468,12 @@ start_ueberzug () {
     [ -e $FIFO ] || { mkfifo "$FIFO" || exit 1 ; }
     ueberzug layer --parser json --silent < "$FIFO" &
     exec 3>"$FIFO"
-    ueberzug_pid="$!"
 }
 stop_ueberzug () {
     exec 3>&-
     rm "$FIFO" > /dev/null 2>&1
     # make sure ueberzug is really dead
-    /bin/kill $ueberzug_pid
+    ps aux | grep 'ueberzug' | awk '{print $2}' | sed '1q' | xargs kill
 }
 
 preview_img () {

--- a/ytfzf
+++ b/ytfzf
@@ -155,9 +155,6 @@ sort_name="${sort_name-}"
 #to detach the video player from the terminal
 detach_player=${detach_player-0}
 
-# in loop mode the player always needs to detach
-[ "$enable_loop" -eq 1 ] && detach_player=1
-
 # misc
 tab_space=$(printf '\t')
 new_line="

--- a/ytfzf
+++ b/ytfzf
@@ -38,6 +38,8 @@ enable_search_hist=${YTFZF_SEARCH_HIST-${enable_search_hist-1}}
 enable_search_hist_menu=${YTFZF_SEARCH_HIST_MENU-${enable_search_hist_menu-0}}
 allow_empty_search_hist=${YTFZF_ALLOW_EMPTY_SEARCH_HIST-${allow_empty_search_hist-0}}
 search_history_prompt=${YTFZF_SEARCH_HISTORY_PROMPT-${search_history_prompt-"> "}}
+#enable/disable persistent
+enable_persistent=${YTFZF_PERSISTENT-${enable_persistent-0}}
 #enable/disable looping
 enable_loop=${YTFZF_LOOP-${enable_loop-0}}
 #enable/disable outputting current track to $current_file
@@ -949,6 +951,8 @@ get_search_query () {
 user_selection () {
 	#remove subscription separators
 	videos_data_clean=$(printf "%s" "$videos_data" | sed "/.*$tab_space$/d")
+    
+    [ "$enable_persistent" -eq 1 ] && persistent_binds=",enter:execute-silent(sh $0 -U \"selected_data_from_file \"{+f})"
 
 	#$selected_data is the video the user picked
 	#picks the first n videos
@@ -967,7 +971,7 @@ user_selection () {
 		export YTFZF_THUMB_DISP_METHOD="$thumb_disp_method"
 		[ "$thumb_disp_method" = "ueberzug" ] && start_ueberzug
 		#thumbnails only work in fzf, use fzf
-		menu_command="fzf -m --tabstop=1 --bind change:top --delimiter=\"$tab_space\" \
+        menu_command="fzf -m --tabstop=1 --bind 'change:top$persistent_binds' --delimiter=\"$tab_space\" \
 		--nth=1,2 --expect='$shortcuts' $FZF_DEFAULT_OPTS \
         --layout=reverse --preview \"sh $0 -U 'preview_img '{}\" \
         	--preview-window \"$PREVIEW_SIDE:50%:noborder:wrap\""
@@ -975,6 +979,7 @@ user_selection () {
 		[ "$thumb_disp_method" = "ueberzug" ] && stop_ueberzug
 		# Deletes thumbnails if no video is selected
 		[ -z "$selected_data" ] && clean_up
+        [ "$enable_persistent" -eq 1 ] && exit
 	#show regular menu
 	else
 		selected_data=$( video_menu "$videos_data" )

--- a/ytfzf
+++ b/ytfzf
@@ -152,6 +152,10 @@ trending_tab="${trending_tab-}"
 sort_name="${sort_name-}"
 #to detach the video player from the terminal
 detach_player=${detach_player-0}
+
+# in persistent mode the player always needs to detach
+[ "$enable_persistent" -eq 1 ] && detach_player=1
+
 # misc
 tab_space=$(printf '\t')
 new_line="

--- a/ytfzf
+++ b/ytfzf
@@ -92,9 +92,12 @@ pid_file="$cache_dir/.pid"
 #list of shortcuts to use in fzf
 #handle_custom_shortcuts will be called if defined (handle_custom_shortcuts can call handle_shortcuts to handle normal shortcuts)
 shortcuts="${shortcuts-alt-l,alt-t,alt-o,alt-v,alt-d,alt-m,alt-s,alt-enter}"
-search_prompt=${search_prompt-Search: }
-#used when getting the html from youtube
+# these keys allow the use of shortcuts without leaving fzf
+persistent_shortcuts="${fzf_select_bindings_play-enter,alt-enter,alt-v,alt-d,alt-o}"
 
+search_prompt=${search_prompt-Search: }
+
+#used when getting the html from youtube
 useragent=${useragent-'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36'}
 #used when fancy_subscriptions_menu is 1
 fancy_subscriptions_text=${fancy_subscriptions_text-             -------%s-------}
@@ -956,7 +959,22 @@ user_selection () {
 	#remove subscription separators
 	videos_data_clean=$(printf "%s" "$videos_data" | sed "/.*$tab_space$/d")
     
-    [ "$enable_loop" -eq 1 ] && loop_binds=",enter:execute-silent(sh $0 -U \"selected_data_from_file \"{+f})"
+    ## PERSISTENT SHORTCUTS
+    if [ "$enable_loop" -eq 1 ]; then
+        loop_binds=
+        # make sure every key code is surrounded by commas
+        shortcuts=",$shortcuts,"
+        IFS=','
+        for key in $persistent_shortcuts; do
+            bind_command=":execute-silent(sh $0 -U \"fzf_bind_command $key \"{+f})"
+            loop_binds="${loop_binds},${key}${bind_command}"
+            # Remove used keys from shortcut
+            shortcuts="$( printf "%s" "$shortcuts" | sed "s/,$key,/,/g" )"
+        done
+        unset IFS
+        shortcuts="${shortcuts%,*}"
+        shortcuts="${shortcuts#*,}"
+    fi
 
 	#$selected_data is the video the user picked
 	#picks the first n videos
@@ -975,7 +993,8 @@ user_selection () {
 		export YTFZF_THUMB_DISP_METHOD="$thumb_disp_method"
 		[ "$thumb_disp_method" = "ueberzug" ] && start_ueberzug
 		#thumbnails only work in fzf, use fzf
-        menu_command="fzf -m --tabstop=1 --bind 'change:top$loop_binds' --delimiter=\"$tab_space\" \
+        menu_command="fzf -m --tabstop=1 \
+        --bind 'change:top$loop_binds' --delimiter=\"$tab_space\" \
 		--nth=1,2 --expect='$shortcuts' $FZF_DEFAULT_OPTS \
         --layout=reverse --preview \"sh $0 -U 'preview_img '{}\" \
         	--preview-window \"$PREVIEW_SIDE:50%:noborder:wrap\""
@@ -990,10 +1009,19 @@ user_selection () {
 	unset videos_data_clean
 }
 
-selected_data_from_file () {
-    selected_data="$( cat "$*" )"
-    [ -z "$selected_data" ] && exit
-	format_user_selection
+fzf_bind_command () {
+    file=${*#* }
+    selected_data="$( cat "$file" )"
+    format_user_selection
+    selected_key=${*%% *}
+	handle_shortcuts
+	case "$?" in
+	    1)
+		save_before_exit
+		clean_up
+		exit ;;
+	    2) continue ;;
+	esac
 	get_video_format
 	get_sub_lang
 	play_url
@@ -1454,7 +1482,7 @@ parse_internal_opt (){
     val=${*#* }
     case "$arg" in
         preview_img*) preview_img "$val"; exit;;
-        selected_data_from_file*) selected_data_from_file "$val";
+        fzf_bind_command*) fzf_bind_command "$val";
     esac
 }
 

--- a/ytfzf
+++ b/ytfzf
@@ -407,7 +407,8 @@ format_menu () {
 	if [ "$is_ext_menu" -eq 0 ]; then
 		#dep_ck fzf here because it is only necessary to use here
 		dep_ck "fzf"
-		menu_command='column -t -s "$tab_space" | fzf -m --bind change:top --tabstop=1 --layout=reverse --delimiter="$tab_space" --nth=1,2 --expect="$key_binds" $FZF_DEFAULT_OPTS'
+		menu_command="column -t -s '$tab_space' | fzf -m --bind 'change:top"$ignore_binds$binds"' --tabstop=1 --layout=reverse --delimiter='$tab_space' --nth=1,2 --expect='$key_binds' $FZF_DEFAULT_OPTS"
+        echo "$menu_command"
 		format_fzf
 	else
 		# Dmenu doesn't render tabs so removing it
@@ -1028,6 +1029,7 @@ user_selection () {
 		[ -z "$selected_data" ] && clean_up
 	#show regular menu
 	else
+        format_menu
 		selected_data=$( video_menu "$videos_data" )
 	fi
 	unset videos_data_clean
@@ -1723,9 +1725,6 @@ fi
 
 # If in auto select mode dont download thumbnails
 [ $auto_select -eq 1 ] || [ $random_select -eq 1 ] && show_thumbnails=0;
-
-#format the menu screen
-format_menu
 
 #if sort_name is define it will define data_sort_key and data_sort_fn
 #otherwise nothing will happen

--- a/ytfzf
+++ b/ytfzf
@@ -38,8 +38,6 @@ enable_search_hist=${YTFZF_SEARCH_HIST-${enable_search_hist-1}}
 enable_search_hist_menu=${YTFZF_SEARCH_HIST_MENU-${enable_search_hist_menu-0}}
 allow_empty_search_hist=${YTFZF_ALLOW_EMPTY_SEARCH_HIST-${allow_empty_search_hist-0}}
 search_history_prompt=${YTFZF_SEARCH_HISTORY_PROMPT-${search_history_prompt-"> "}}
-#enable/disable persistent
-enable_persistent=${YTFZF_PERSISTENT-${enable_persistent-0}}
 #enable/disable looping
 enable_loop=${YTFZF_LOOP-${enable_loop-0}}
 #enable/disable outputting current track to $current_file
@@ -153,8 +151,8 @@ sort_name="${sort_name-}"
 #to detach the video player from the terminal
 detach_player=${detach_player-0}
 
-# in persistent mode the player always needs to detach
-[ "$enable_persistent" -eq 1 ] && detach_player=1
+# in loop mode the player always needs to detach
+[ "$enable_loop" -eq 1 ] && detach_player=1
 
 # misc
 tab_space=$(printf '\t')
@@ -959,7 +957,7 @@ user_selection () {
 	#remove subscription separators
 	videos_data_clean=$(printf "%s" "$videos_data" | sed "/.*$tab_space$/d")
     
-    [ "$enable_persistent" -eq 1 ] && persistent_binds=",enter:execute-silent(sh $0 -U \"selected_data_from_file \"{+f})"
+    [ "$enable_loop" -eq 1 ] && loop_binds=",enter:execute-silent(sh $0 -U \"selected_data_from_file \"{+f})"
 
 	#$selected_data is the video the user picked
 	#picks the first n videos
@@ -978,7 +976,7 @@ user_selection () {
 		export YTFZF_THUMB_DISP_METHOD="$thumb_disp_method"
 		[ "$thumb_disp_method" = "ueberzug" ] && start_ueberzug
 		#thumbnails only work in fzf, use fzf
-        menu_command="fzf -m --tabstop=1 --bind 'change:top$persistent_binds' --delimiter=\"$tab_space\" \
+        menu_command="fzf -m --tabstop=1 --bind 'change:top$loop_binds' --delimiter=\"$tab_space\" \
 		--nth=1,2 --expect='$shortcuts' $FZF_DEFAULT_OPTS \
         --layout=reverse --preview \"sh $0 -U 'preview_img '{}\" \
         	--preview-window \"$PREVIEW_SIDE:50%:noborder:wrap\""
@@ -986,7 +984,6 @@ user_selection () {
 		[ "$thumb_disp_method" = "ueberzug" ] && stop_ueberzug
 		# Deletes thumbnails if no video is selected
 		[ -z "$selected_data" ] && clean_up
-        [ "$enable_persistent" -eq 1 ] && exit
 	#show regular menu
 	else
 		selected_data=$( video_menu "$videos_data" )

--- a/ytfzf
+++ b/ytfzf
@@ -1010,8 +1010,8 @@ user_selection () {
 }
 
 fzf_bind_command () {
-    file=${*#* }
-    selected_data="$( cat "$file" )"
+    args=$*
+    selected_data="$( cat "${args#* }" )"
     format_user_selection
     selected_key=${*%% *}
 	handle_shortcuts

--- a/ytfzf
+++ b/ytfzf
@@ -408,7 +408,6 @@ format_menu () {
 		#dep_ck fzf here because it is only necessary to use here
 		dep_ck "fzf"
 		menu_command="column -t -s '$tab_space' | fzf -m --bind 'change:top"$ignore_binds$binds"' --tabstop=1 --layout=reverse --delimiter='$tab_space' --nth=1,2 --expect='$key_binds' $FZF_DEFAULT_OPTS"
-        echo "$menu_command"
 		format_fzf
 	else
 		# Dmenu doesn't render tabs so removing it

--- a/ytfzf
+++ b/ytfzf
@@ -91,9 +91,12 @@ pid_file="$cache_dir/.pid"
 #> config settings
 #list of shortcuts to use in fzf
 #handle_custom_shortcuts will be called if defined (handle_custom_shortcuts can call handle_shortcuts to handle normal shortcuts)
+# These binds are used for standard select function
+select_binds="${select_binds-enter,double-click}"
+# shortcuts are used for alternative functions apart from select
 shortcuts="${shortcuts-alt-l,alt-t,alt-o,alt-v,alt-d,alt-m,alt-s,alt-enter}"
-# these keys allow the use of shortcuts without leaving fzf
-persistent_shortcuts="${persistent_shortcuts-enter,alt-enter,alt-v,alt-d,alt-o}"
+# these keys allow the use of shortcuts or select binds without leaving fzf
+persistent_shortcuts="${persistent_shortcuts-enter,alt-enter,alt-v,alt-d,alt-o,double-click}"
 
 search_prompt=${search_prompt-Search: }
 
@@ -956,9 +959,14 @@ get_search_query () {
 }
 
 persistent_shortcuts () {
+    # binds for `fzf --binds`
     binds=
+
     # make sure every key code is surrounded by commas
-    shortcuts=",$shortcuts,"
+    # by default, select_binds are shortcuts unless in persistent_binds
+    shortcuts=",${shortcuts},${select_binds},"
+
+    # Build fzf --bind command
     IFS=','
     for key in $persistent_shortcuts; do
         bind_command=":execute-silent(sh $0 -U \"fzf_bind_command $key \"{+f})"
@@ -966,7 +974,20 @@ persistent_shortcuts () {
         # Remove used keys from shortcut
         shortcuts="$( printf "%s" "$shortcuts" | sed "s/,$key,/,/g" )"
     done
+
+    # if in neither persistent_bind, shortcut or select_binds, ignore
+    # if in persistent_bind, always ignore
+    ignore_keys="enter,double-click"
+    ignore_binds=
+    for key in $ignore_keys; do
+        printf "%s%s" "$binds" "$shortcuts" | grep -q ",$key," || \
+            ignore_binds="${ignore_binds},${key}:ignore"
+        printf "%s" "$shortcuts" | grep -q ",$key," || continue
+        ignore_binds="${ignore_binds},${key}:ignore"
+    done
     unset IFS
+
+    # remove leading and tailing , in shortcuts
     shortcuts="${shortcuts%,*}"
     shortcuts="${shortcuts#*,}"
 }
@@ -997,7 +1018,7 @@ user_selection () {
 		[ "$thumb_disp_method" = "ueberzug" ] && start_ueberzug
 		#thumbnails only work in fzf, use fzf
         menu_command="fzf -m --tabstop=1 \
-        --bind 'change:top$binds' --delimiter=\"$tab_space\" \
+        --bind 'change:top$ignore_binds$binds' --delimiter=\"$tab_space\" \
 		--nth=1,2 --expect='$shortcuts' $FZF_DEFAULT_OPTS \
         --layout=reverse --preview \"sh $0 -U 'preview_img '{}\" \
         	--preview-window \"$PREVIEW_SIDE:50%:noborder:wrap\""
@@ -1034,6 +1055,9 @@ fzf_bind_command () {
 
 handle_shortcuts () {
     [ -z "$selected_key" ] && return 0
+
+    printf ",%s," "$select_binds" | grep -q ",$selected_key," && return 0
+
     #creates splits the variable shortcuts by , and assigns a variable to each string
     #ei: $urls_shortcut will be equal to the first keybind
     IFS="," read -r \

--- a/ytfzf
+++ b/ytfzf
@@ -93,7 +93,7 @@ pid_file="$cache_dir/.pid"
 #handle_custom_shortcuts will be called if defined (handle_custom_shortcuts can call handle_shortcuts to handle normal shortcuts)
 shortcuts="${shortcuts-alt-l,alt-t,alt-o,alt-v,alt-d,alt-m,alt-s,alt-enter}"
 # these keys allow the use of shortcuts without leaving fzf
-persistent_shortcuts="${fzf_select_bindings_play-enter,alt-enter,alt-v,alt-d,alt-o}"
+persistent_shortcuts="${persistent_shortcuts-enter,alt-enter,alt-v,alt-d,alt-o}"
 
 search_prompt=${search_prompt-Search: }
 


### PR DESCRIPTION
This PR ads a new option `enable_persistent=1` which launches `ytfzf` in persistent mode, in this mode the fzf --bind option is used to execute and open the player without exiting fzf.

This has the advantage of:
- no looping, fzf will just persist
- unlike looping, the pointer will stay at the last position (far less annoying)