### PR TITLE
Fix error with --show-thumbnails option

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -641,7 +641,7 @@ interface_thumbnails () {
 	jq -r '.[]|[.title,"'"$gap_space"'|"+.channel,"|"+.duration,"|"+.views,"|"+.date,"|"+.ID]|@tsv' < "$video_json_file" |
 	sort_video_data_fn |
 	fzf -m \
-	--preview "sh $0 -U preview_img '"$thumbnail_viewer"' {} '"$video_json_file"'" \
+	--preview "sh $0 -U preview_img '""$thumbnail_viewer""' {} '""$video_json_file""'" \
 	--preview-window "left:50%:wrap" --layout=reverse |
 	trim_id > "$selected_id_file"
 


### PR DESCRIPTION
The unquoted variables caused an error with the `-t` option if there was a whitespace in the search query. Quoting them fixes it.

```
$ ytfzf -t "naruto amv"
Scraping site...
Fetching thumbnails...
DL% UL%  Dled  Uled  Xfers  Live   Qd Total     Current  Left    Speed
100 --  2439k     0    29     0     0  0:00:01  0:00:01 --:--:-- 1602k
unknown option: amv-43818/videos_json'
```