### PR TITLE
feat: New options `ytdl-opts` and `ytdl-path`

### DIFF
--- a/docs/man/ytfzf.1
+++ b/docs/man/ytfzf.1
@@ -64,6 +64,15 @@ Auto\-play a random result,
 .B \-L
 Print the URL of the selected videos.
 .TP
+.BI \-\-ytdl\-opts= option
+Pass command\-line options to youtube\-dl when downloading.
+.EX
+.RB "example: " \-\-ytdl\-opts= "\fI\'\-o ~/Videos/%(title)s.%(ext)s\'"
+.EE
+.TP
+.BI \-\-ytdl\-path= path
+Specify the path to youtube\-dl or a fork of youtube\-dl for downloading.
+.TP
 .BI \-c " scraper"
 Set which scraper to use.
 The currently supported builtin scrapers are

--- a/docs/man/ytfzf.5
+++ b/docs/man/ytfzf.5
@@ -158,6 +158,16 @@ The amount of videos to scrape per channel when getting subscriptions.
 .br
 .RI default: " 10"
 
+.TP
+.RB $ ytdl_opts
+The command\-line options to pass to youtube\-dl when downloading.
+
+.TP
+.RB $ ytdl_path
+Path to youtube\-dl or a fork of youtube\-dl for downloading.
+.br
+.RI default: " youtube\-dl"
+
 .SS FUNCTIONS
 .PP
 Sometimes a variable is not good enough, instead functions should be defined.

--- a/ytfzf
+++ b/ytfzf
@@ -73,8 +73,8 @@ function_exists "audio_player" || audio_player () {
 }
 function_exists "downloader" || downloader () {
 	case $is_audio_only in
-	    0) youtube-dl -f "${video_pref}" $ytdl_opts "$@"	;;
-	    1) youtube-dl -x $ytdl_opts "$@" ;;
+	    0) ${ytdl_path:-youtube-dl} -f "${video_pref}" $ytdl_opts "$@"	;;
+	    1) ${ytdl_path:-youtube-dl} -x $ytdl_opts "$@" ;;
 	esac
 }
 
@@ -753,6 +753,7 @@ parse_opt () {
 		video-pref) video_pref=$optarg ;;
 		detach) is_detach=${optarg:-1} ;;
 		ytdl-opts) ytdl_opts="$optarg" ;;
+		ytdl-path) ytdl_path="$optarg" ;;
 	esac
 }
 

--- a/ytfzf
+++ b/ytfzf
@@ -73,8 +73,8 @@ function_exists "audio_player" || audio_player () {
 }
 function_exists "downloader" || downloader () {
 	case $is_audio_only in
-	    0) youtube-dl -f "${video_pref}" "$@"	;;
-	    1) youtube-dl -x "$@" ;;
+	    0) youtube-dl -f "${video_pref}" $ytdl_opts "$@"	;;
+	    1) youtube-dl -x $ytdl_opts "$@" ;;
 	esac
 }
 
@@ -752,6 +752,7 @@ parse_opt () {
 		sort) is_sort=${optarg:-1} ;;
 		video-pref) video_pref=$optarg ;;
 		detach) is_detach=${optarg:-1} ;;
+		ytdl-opts) ytdl_opts="$optarg" ;;
 	esac
 }
 


### PR DESCRIPTION
1. `ytdl-opts`: For passing command-line options to youtube-dl
> ```
> ytfzf -d --ytdl-opts='-o ~/Videos/%(title)s.%(ext)s'
> ytfzf -d --ytdl-opts='--config-location ~/.config/youtube-dl/alt-config'
> ```
2. `ytdl-path`: For using a fork of youtube-dl
> ```
> ytfzf -d --ytdl-path=yt-dlp
> ```

Though these options can already be set by defining  the `downloader` function, this might make it easier for users who aren't familiar with shell scripting.