### PR TITLE
feat: Add option to convert invidious to yt links

### DIFF
--- a/docs/man/ytfzf.1
+++ b/docs/man/ytfzf.1
@@ -179,6 +179,10 @@ Same as \-c, but keeps the default scrape as well.
 .TP
 .BI \-\-scraper-=scrapers
 Removes scraper from list of scrapers to use
+.TP
+.B \-\-force\-youtube
+When using the \fIyoutube\fR scraper,
+convert the invidious links to youtube links before playing/downloading.
 .RE
 
 .PP

--- a/docs/man/ytfzf.5
+++ b/docs/man/ytfzf.5
@@ -121,6 +121,12 @@ Whether or not to download selected video(s) instead of playing them.
 .RI default: " 0"
 
 .TP
+.RB $ yt_video_link_domain
+The domain to play youtube videos from (does not apply to odysee and peertube, or youtube playlists)
+.br
+.RI default: " $invidious_instance"
+
+.TP
 .RB $ info_to_print
 The information to print instead of playing a video.
 The available options for this variable are:

--- a/ytfzf
+++ b/ytfzf
@@ -180,6 +180,7 @@ function_exists "downloader" || downloader () {
 : "${yt_thumbnail_quality=default}"
 : ${sub_link_count:=10}
 : "${invidious_instance:=ytprivate.com}"
+: "${yt_video_link_domain:=$invidious_instance}"
 : ${pages_to_scrape:=1}
 
 : "${search_sort_by:=relevance}"
@@ -301,7 +302,7 @@ _youtube_channel_json () {
 	jq '[ .contents | ..|.gridVideoRenderer? | select(. !=null) |
 	    {
 	    	ID: .videoId,
-			url: "https://www.youtube.com/watch?v=\(.videoId)",
+			url: "https://'"$yt_video_link_domain"'/watch?v=\(.videoId)",
 	    	title: .title.runs[0].text,
 	    	channel: "'"$channel_name"'",
 	    	thumbs: .thumbnail.thumbnails[0].url|sub("\\?.*";""),
@@ -387,7 +388,7 @@ _invidious_search_json_live () {
 	jq '[ .[] | select(.type=="video" and .liveNow==true) |
 		{
 			ID: .videoId,
-			url: "https://'"${invidious_instance}"'/watch?v=\(.videoId)",
+			url: "https://'"${yt_video_link_domain}"'/watch?v=\(.videoId)",
 			title: "[live] \(.title)",
 			channel: .author,
 			thumbs: .videoThumbnails['"$_yt_thumbnail_quality_index"'].url ,
@@ -398,7 +399,7 @@ _invidious_search_json_videos () {
 	jq '[ .[] | select(.type=="video" and .liveNow==false) |
 		{
 			ID: .videoId,
-			url: "https://'"${invidious_instance}"'/watch?v=\(.videoId)",
+			url: "https://'"${yt_video_link_domain}"'/watch?v=\(.videoId)",
 			title: .title,
 			channel: .author,
 			thumbs: .videoThumbnails['"$_yt_thumbnail_quality_index"'].url ,
@@ -414,7 +415,7 @@ _invidious_channel_json () {
 	jq '[ .latestVideos |.[] |
 	    {
 	    	ID: .videoId,
-		url: "https://'"${invidious_instance}"'/watch?v=\(.videoId)",
+		url: "https://'"${yt_video_link_domain}"'/watch?v=\(.videoId)",
 	    	title: .title,
 	    	channel: "'"$channel_name"'",
 		thumbs: .videoThumbnails['"$_yt_thumbnail_quality_index"'].url ,
@@ -895,7 +896,7 @@ parse_opt () {
 		detach) is_detach=${optarg:-1} ;;
 		ytdl-opts) ytdl_opts="$optarg" ;;
 		ytdl-path) ytdl_path="$optarg" ;;
-		force-youtube) force_yt=${optarg:-1} ;;
+		force-youtube) yt_video_link_domain="www.youtube.com" ;;
 		info-print-exit) exit_on_info_to_print="${optarg:-1}" ;;
 		sort-by) search_sort_by="$optarg" ;;
 		upload-date) search_upload_date="$optarg" ;;
@@ -1064,11 +1065,8 @@ while :; do
 
 	[ $enable_hist -eq 1 ] && add_to_hist "$ytfzf_video_json_file" < "$ytfzf_selected_urls"
 
-	if [ $force_yt -eq 1 ]; then
-		format_urls < "$ytfzf_selected_urls" | sed "s/${invidious_instance}/www.youtube.com/g" | open_player
-	else
-		format_urls < "$ytfzf_selected_urls" | open_player
-	fi
+	format_urls < "$ytfzf_selected_urls" | open_player
+
 	[ $is_loop -eq 0 ] || [ ! -s "$ytfzf_selected_urls" ] && break
 done
 #}}}

--- a/ytfzf
+++ b/ytfzf
@@ -895,6 +895,7 @@ parse_opt () {
 		detach) is_detach=${optarg:-1} ;;
 		ytdl-opts) ytdl_opts="$optarg" ;;
 		ytdl-path) ytdl_path="$optarg" ;;
+		force-youtube) force_yt=${optarg:-1} ;;
 		info-print-exit) exit_on_info_to_print="${optarg:-1}" ;;
 		sort-by) search_sort_by="$optarg" ;;
 		upload-date) search_upload_date="$optarg" ;;
@@ -1063,7 +1064,11 @@ while :; do
 
 	[ $enable_hist -eq 1 ] && add_to_hist "$ytfzf_video_json_file" < "$ytfzf_selected_urls"
 
-	format_urls < "$ytfzf_selected_urls" | open_player
+	if [ $force_yt -eq 1 ]; then
+		format_urls < "$ytfzf_selected_urls" | sed "s/${invidious_instance}/www.youtube.com/g" | open_player
+	else
+		format_urls < "$ytfzf_selected_urls" | open_player
+	fi
 	[ $is_loop -eq 0 ] || [ ! -s "$ytfzf_selected_urls" ] && break
 done
 #}}}


### PR DESCRIPTION
Add a `--force-youtube` option to convert the invidious links to youtube links before playing/downloading while still using invidious for scraping.

This might be good for some uses such as scripting with the `-L` flag or if the invidious instances are too slow.

(edit: I amended the commit to add 'www' to the youtube url and `/g` to the sed command.)