### PR TITLE
feat: add kitty/icat thumbnail viewer support

### DIFF
--- a/docs/man/ytfzf.1
+++ b/docs/man/ytfzf.1
@@ -141,6 +141,9 @@ Imagemagick's display module.
 .IR w3m
 Uses a workaround to get w3m to work in fzf, may take up a lot of cpu.
 .TP
+.IR kitty
+uses kitty's builtin icat to display an image.
+.TP
 .IR <custom>
 Additional viewers can be put into $YTFZF_THUMBNAIL_VIEWERS_DIR.
 .RE

--- a/docs/man/ytfzf.5
+++ b/docs/man/ytfzf.5
@@ -211,6 +211,9 @@ Uses imagemagick's preview image
 Uses a workaround to get w3m to work in fzf, may take up a lot of cpu,
 make sure $w3mimgdisplay_path is set to the path to w3mimgdisplay
 .TP
+.IR kitty
+Uses kitty's builtin icat to display an image.
+.TP
 .IR custom
 Calls the user defined img_display_function()
 .TP

--- a/ytfzf
+++ b/ytfzf
@@ -966,7 +966,7 @@ preview_start () {
 			ueberzug layer --parser simple < "$UEBERZUG_FIFO" 2>/dev/null &
 			exec 3> "$UEBERZUG_FIFO" # to keep the fifo open
 			;;
-		chafa|chafa-16|chafa-tty|catimg|catimg-256|display|w3m) : ;;
+		chafa|chafa-16|chafa-tty|catimg|catimg-256|display|kitty|w3m) : ;;
 		*)
 			"$thumbnail_viewer" "start" "$FZF_PREVIEW_COLUMNS" "$FZF_PREVIEW_LINES" 2>/dev/null ;;
 	esac
@@ -977,7 +977,7 @@ preview_stop () {
 		ueberzug)
 			exec 3>&- # close file descriptor 3, closing ueberzug
 			;;
-		chafa|chafa-16|chafa-tty|catimg|catimg-256|display|w3m) : ;;
+		chafa|chafa-16|chafa-tty|catimg|catimg-256|display|kitty|w3m) : ;;
 		*)
 			"$thumbnail_viewer" "stop" "$FZF_PREVIEW_COLUMNS" "$FZF_PREVIEW_LINES" 2>/dev/null ;;
 	esac
@@ -1062,6 +1062,13 @@ preview_display_image () {
 			dep_check "display" || die 3 "\nimagemagick is not installed\n"
 			killall display
 			display "$thumb_dir/${id}.jpg" ;;
+		kitty)
+			printf '\n'
+			[ "$TERM" = "xterm-kitty" ] || die 3 "\nnot running inside kitty\n"
+			dep_check "kitty" || die 3 "\nkitty is not installed\n"
+			get_ueberzug_positioning "$FZF_PREVIEW_COLUMNS" "$FZF_PREVIEW_LINES" "$fzf_preview_side"
+			kitty +kitten icat --clear --transfer-mode stream
+			kitty +kitten icat --place "${width}x${height}@${x}x${y}" --scale-up --transfer-mode stream "$thumb_dir/${id}.jpg" ;;
 		w3m)
 			while true; do
 				printf "%b\n%s;\n" "0;1;10;130;$((FZF_PREVIEW_COLUMNS*5));$((FZF_PREVIEW_COLUMNS*3));;;;;$thumb_dir/${id}.jpg" 3 | $w3mimgdisplay_path

--- a/ytfzf
+++ b/ytfzf
@@ -1063,8 +1063,6 @@ preview_display_image () {
 			killall display
 			display "$thumb_dir/${id}.jpg" ;;
 		kitty)
-			printf '\n'
-			[ "$TERM" = "xterm-kitty" ] || die 3 "\nnot running inside kitty\n"
 			dep_check "kitty" || die 3 "\nkitty is not installed\n"
 			get_ueberzug_positioning "$FZF_PREVIEW_COLUMNS" "$FZF_PREVIEW_LINES" "$fzf_preview_side"
 			kitty +kitten icat --clear --transfer-mode stream


### PR DESCRIPTION
Tried this and it works great on both x11 and wayland (it's non-generic but it's still something for #64)

Prefer this over ueberzug on x11 as well given the image will work properly when switching terminal tabs.

I've seen mentions of using `transfer-mode file` with fzf and not having a separate --clear, but it displayed nothing if I did either of these. Not that I know kitty/icat that well so there may be something to improve.