### PR TITLE
fix Makefile to make more MacOS friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/man

--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,22 @@ PROG=ytfzf
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
     PREFIX = /usr/local/bin
+	MANPREFIX = /usr/local/share
 endif
 ifeq ($(UNAME), FreeBSD)
     PREFIX = /usr/local/bin
+	MANPREFIX = /usr/share
 endif
 ifeq ($(UNAME), Linux)
     PREFIX = /usr/bin
+	MANPREFIX = /usr/share
 endif
 
 man:
 	gzip -c docs/man/ytfzf.1 > docs/man/ytfzf.1.gz
 	gzip -c docs/man/ytfzf.5 > docs/man/ytfzf.5.gz
-	install docs/man/ytfzf.1.gz /usr/share/man/man1
-	install docs/man/ytfzf.5.gz /usr/share/man/man5
+	install docs/man/ytfzf.1.gz ${MANPREFIX}/man/man1
+	install docs/man/ytfzf.5.gz ${MANPREFIX}/man/man5
 
 install:
 	chmod 755 $(PROG)


### PR DESCRIPTION
Moving man pages to /usr/local/share instead of /usr/share for MacOS bc /usr is part of a readonly disk in Catalina 