### PR TITLE
feat: ard scraper

### DIFF
--- a/addons/scrapers/ard
+++ b/addons/scrapers/ard
@@ -14,7 +14,7 @@ _ard_get_thumbnail_width () {
 
 _ard_correct_ytdl_pref () {
 	ytdl_pref="best"
-	print_warning "bestvideo ist not supported for ARD, fallback to best\n"
+	[ $__is_fzf_preview -eq 0 ] && print_warning "ytdl_pref $1 ist not supported for ARD, fallback to best\n"
 }
 
 scrape_ard () {
@@ -44,9 +44,13 @@ scrape_ard () {
 }
 
 on_startup_ard () {
-	# This is neccessary because ytdl only plays the audio when bestvideo is chosen (as of 2022-03-28)
-	awk \
+	# With ytdl_pref="" or ytdl="bestvideo" only audio is played (as of 2022-03-28), this fixes this:
+	if [ -z "$ytdl_pref" ]; then
+		_ard_correct_ytdl_pref "empty string" 
+	else
+		awk \
 		-v string="$ytdl_pref" \
 		-v substring="bestvideo" ' \
-		BEGIN { if (match(string, substring)) {exit 1} }' || _ard_correct_ytdl_pref
+		BEGIN { if (match(string, substring)) {exit 1} }' || _ard_correct_ytdl_pref "bestvideo"
+	fi
 }

--- a/addons/scrapers/ard
+++ b/addons/scrapers/ard
@@ -34,7 +34,7 @@ scrape_ard () {
 			thumbs: (.images.aspect16x9.src | gsub("{width}"; "'"$_thumbnail_width"'")), 
 			duration: "\(.duration / 60 | floor):\(pad_left(2; .duration % 60))",
 			date: "\(.broadcastedOn | fromdateiso8601 | strftime("%Y-%m-%d"))",
-			description: .longSynopsis,
+			description: .show.synopsis,
 		}]' < "$_tmp_json" > "$output_json_file"
 	
 }

--- a/addons/scrapers/ard
+++ b/addons/scrapers/ard
@@ -13,7 +13,7 @@ _ard_get_thumbnail_width() {
 }
 
 scrape_ard () {
-	search=$(echo "$1" | sed 's/ /+/')
+	search=$(echo "$1" | sed 's/ /+/g')
 	output_json_file="$2"
 	search_url="https://api.ardmediathek.de/search-system/mediathek/ard/search/vods?query=$search&pageNumber=0&pageSize=$((20 * pages_to_scrape))"
 	_tmp_json="${session_temp_dir}/ard_search.json"
@@ -35,6 +35,12 @@ scrape_ard () {
 			duration: "\(.duration / 60 | floor):\(pad_left(2; .duration % 60))",
 			date: "\(.broadcastedOn | fromdateiso8601 | strftime("%Y-%m-%d"))",
 			description: .show.synopsis,
-		}]' < "$_tmp_json" > "$output_json_file"
-	
+		}]' < "$_tmp_json" >> "$output_json_file"
+}
+
+on_startup_ard () {
+	# This is neccessary because ytdl only plays the audio when bestvideo is chosen (as of 2022-03-28)
+	case "bestvideo" in
+		*$ytdl_pref*) ytdl_pref="best" ;;
+	esac
 }

--- a/addons/scrapers/ard
+++ b/addons/scrapers/ard
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-_ard_get_thumbnail_width() {
+_ard_get_thumbnail_width () {
 	case "$1" in
 		maxres) echo "4096" ;;		# 4K
 		maxresdefault) _ard_get_thumbnail_width "maxres" ;;
@@ -10,6 +10,11 @@ _ard_get_thumbnail_width() {
 		sddefault) _ard_get_thumbnail_width "medium" ;;
 		*) _ard_get_thumbnail_width "default" ;;
 	esac
+}
+
+_ard_correct_ytdl_pref () {
+	ytdl_pref="best"
+	print_warning "bestvideo ist not supported for ARD, fallback to best\n"
 }
 
 scrape_ard () {
@@ -40,7 +45,8 @@ scrape_ard () {
 
 on_startup_ard () {
 	# This is neccessary because ytdl only plays the audio when bestvideo is chosen (as of 2022-03-28)
-	case "bestvideo" in
-		*$ytdl_pref*) ytdl_pref="best" ;;
-	esac
+	awk \
+		-v string="$ytdl_pref" \
+		-v substring="bestvideo" ' \
+		BEGIN { if (match(string, substring)) {exit 1} }' || _ard_correct_ytdl_pref
 }

--- a/addons/scrapers/ard
+++ b/addons/scrapers/ard
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+_ard_get_thumbnail_width() {
+	case "$1" in
+		maxres) echo "4096" ;;		# 4K
+		maxresdefault) _ard_get_thumbnail_width "maxres" ;;
+		high) echo "1920" ;;		# Full HD
+		default) _ard_get_thumbnail_width "high" ;;
+		medium) echo "960" ;; 		# 540p
+		sddefault) _ard_get_thumbnail_width "medium" ;;
+		*) _ard_get_thumbnail_width "default" ;;
+	esac
+}
+
+scrape_ard () {
+	search=$(echo "$1" | sed 's/ /+/')
+	output_json_file="$2"
+	search_url="https://api.ardmediathek.de/search-system/mediathek/ard/search/vods?query=$search&pageNumber=0&pageSize=$((20 * pages_to_scrape))"
+	_tmp_json="${session_temp_dir}/ard_search.json"
+	_thumbnail_width=$(_ard_get_thumbnail_width "$thumbnail_quality")
+	curl "$search_url" > "$_tmp_json"
+	jq '
+	def pad_left(n; num):
+		num | tostring |
+			if (n > length) then ((n - length) * "0") + (.) else . end
+		;
+	[.teasers[]|
+		{
+			scraper: "ard", 
+			ID: .id,
+			url: "https://www.ardmediathek.de/video/\(.id)",
+			title: .longTitle,
+			channel: .show.title,
+			thumbs: (.images.aspect16x9.src | gsub("{width}"; "'"$_thumbnail_width"'")), 
+			duration: "\(.duration / 60 | floor):\(pad_left(2; .duration % 60))",
+			date: "\(.broadcastedOn | fromdateiso8601 | strftime("%Y-%m-%d"))",
+			description: .longSynopsis,
+		}]' < "$_tmp_json" > "$output_json_file"
+	
+}


### PR DESCRIPTION
This is a scraper for the media library from the german broadcast service [ARD](https://www.ardmediathek.de/).

# Features
- scrapes the API from [ARD](https://www.ardmediathek.de/) and get the video link
- thumbnail fetching
- respects thumbnail resolution choice
- `--pages` flag is supported. It is implemented as a multiplication of the default page size. This avoids making multiple connections.

# Not supported
- `alt-p` to search for next page

# Bugs
With the default video player, it opens only the audio. With following function in `conf.sh` it opens the video for me
```sh
video_player () {
	mpv "$@"
}
```

# Examples
Basic example:
```sh
ytfzf -c ard tagesschau
```

Example with amount of pages:
```sh
ytfzf -c ard --pages=3 sport
```

# Credits
The `pad_left` function is copied from the [source code of ytfzf](https://github.com/pystardust/ytfzf/blob/9f63601e23de30d15a2337b33cac0ecf9a2bfabf/ytfzf#L678-L681). I didn't mentioned it in the source code, because it is contributed to the same projekt. If you think it is nevertheless necessary, I can add it.