### PR TITLE
Fixes related to displaying video data

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -1298,7 +1298,7 @@ download_thumbnails () {
 }
 
 get_video_json_attr () {
-	sed -n 's/^[[:space:]]*"'"$1"'":[[:space:]]*"\([^\n]*\)",*/\1/p' <<EOF | xargs -0 printf '%b'
+	sed -n 's/^[[:space:]]*"'"$1"'":[[:space:]]*"\([^\n]*\)",*/\1/p' <<EOF | sed 's/\\\([\\"]\)/\1/g'
 $_correct_json
 EOF
 }

--- a/ytfzf
+++ b/ytfzf
@@ -1298,7 +1298,7 @@ download_thumbnails () {
 }
 
 get_video_json_attr () {
-	sed -n 's/^[[:space:]]*"'"$1"'":[[:space:]]*"\([^"\n]*\)",*/\1/p' <<EOF
+	sed -n 's/^[[:space:]]*"'"$1"'":[[:space:]]*"\([^\n]*\)",*/\1/p' <<EOF | xargs -0 printf '%b'
 $_correct_json
 EOF
 }
@@ -1537,7 +1537,7 @@ preview_img () {
 	url=${line##*|}
 
 	#make sure all variables are set{{{
-	_correct_json=$(jq -r --arg url "$url" '[.[]|select(.url==$url)]|unique_by(.ID)[0]' < "$video_json_file")
+	_correct_json=$(jq -nr --arg url "$url" '[inputs[]|select(.url==$url)][0]' < "$video_json_file")
 	id="$(get_video_json_attr "ID")"
 	title="$(get_video_json_attr "title")"
 	channel="$(get_video_json_attr "channel")"
@@ -1574,7 +1574,7 @@ interface_thumbnails () {
 
 	# ytfzf -U preview_img ueberzug {} "$video_json_file"
 	#fzf_preview_side will get reset if we don't pass it in
-	jq -r '.[]|[.title,"'"$gap_space"'|"+.channel,"|"+.duration,"|"+.views,"|"+.date,"|"+.url]|@tsv' < "$video_json_file" |
+	jq -r '.[]|[.title,"'"$gap_space"'|"+.channel,"|"+.duration,"|"+.views,"|"+.date,"|"+.url]|join("\t")' < "$video_json_file" |
 	sort_video_data_fn |
 	SHELL="" fzf -m \
 	--preview "__is_fzf_preview=1 fzf_preview_side='$fzf_preview_side' scrape='$scrape' thumb_dir='$thumb_dir' YTFZF_PID='$YTFZF_PID' UEBERZUG_FIFO='$UEBERZUG_FIFO' $0 -U preview_img '$thumbnail_viewer' {} '$video_json_file'" \


### PR DESCRIPTION
### Summary
1. Fixed displaying details of video with title containing quotes - when parsing JSON string object to text, current approach is to find first two quotes in the object; this PR assumes that closing quote is the last one in parsed line, using the fact that sed's `*` matches greedily
2. Fixed displaying escaped backslashes in search results - jq's `@tsv` filter escapes backslashes, which is not necessary here; alternative that does not do that is `join("\t")`
3. Fixed issues with videos that occur multiple times in search results due to paging (repeated details, thumbnail preview not updating)
   - note that this PR removes `unique_by(.ID)` filter as I do not see any reason to leave it (after filtering by URL we can assume that objects left are equal), but it can be restored if I am mistaken

### Screenshots
1.
   - before:
![before_1](https://user-images.githubusercontent.com/42496375/161945397-e64e6ca3-da43-458b-a755-b99ae404768e.png)
   - after:
![after_1](https://user-images.githubusercontent.com/42496375/161945419-019f7600-178b-4134-b4b3-b303c284e402.png)
2.
   - before:
![before_2](https://user-images.githubusercontent.com/42496375/161945466-7ee47fef-d417-4b46-867c-c56cca7cd7f6.png)
   - after:
![after_2](https://user-images.githubusercontent.com/42496375/161945487-9a04b7cd-2788-44cd-a683-585cd5048fa0.png)
3.
   - before:
![before_3](https://user-images.githubusercontent.com/42496375/161945515-1cb1865c-5121-4656-8894-f5e5094f33da.png)
(it's worth noting that thumbnail of a previous video is shown, and "no image found" error is displayed behind it)
   - after:
![after_3](https://user-images.githubusercontent.com/42496375/161945534-d73c4f4d-9b4f-400b-9c7f-e2151701393f.png)