### PR TITLE
Allow for multiline env vars when generating and reading /tmp/ytfzf-env

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -400,7 +400,7 @@ set_vars () {
     #save the ecurrent environment so that any user set variables will be saved
     if [ "$check_exists" -eq 1 ]; then
 	tmp_env=/tmp/ytfzf-env
-	env > "$tmp_env"
+	export -p > "$tmp_env"
     fi
 
     gap_space="                                                                                                                   "
@@ -484,12 +484,28 @@ set_vars () {
 
     #read from environment to reset any variables to what the user set
     if [ "$check_exists" -eq 1 ]; then
+       _vars=$(awk -F"\n" '
+BEGIN {
+    vars=""
+}
+/^[^"]+="/{
+    vars=vars "\n" $1
+}
+!/^[^"]+="/{
+    vars=vars "\t" $1
+}
+END{
+    print vars;
+}
+' < "$tmp_env")
 	while read -r variable; do
-	    export "${variable?}"
-	done < "$tmp_env"
-	rm "$tmp_env"
+           [ -z "$variable" ] && continue
+           export "${variable#export }"
+       done <<EOF
+$data
+EOF
     fi
-    unset check_exists
+    unset check_exists _vars variable
 }
 
 set_vars "${check_vars_exists:-1}"

--- a/ytfzf
+++ b/ytfzf
@@ -502,7 +502,7 @@ END{
            [ -z "$variable" ] && continue
            export "${variable#export }"
        done <<EOF
-$data
+$_vars
 EOF
     fi
     unset check_exists _vars variable


### PR DESCRIPTION
If you want to have a multiline string anywhere in your environment such as
```shell
export FZF_DEFAULT_OPTS='--border
--bind "ctrl-y:execute-silent(echo {} | xclip)+abort"
--preview "(pistol {}) 2> /dev/null | head -500"'
```
`ytfzf` will error with
```
/usr/bin/ytfzf: line 488: export: --: invalid option
export: usage: export [-fn] [name[=value] ...] or export -p
```

because it is trying to `export`  `--bind`

(I realize I could put it all on one line but it looks neater in my zshrc this way and it works with fzf just fine) :stuck_out_tongue: 

This change set tells `env` to delimit variable definitions by the special unix null character, by calling it with `-0`. This character is much less likely to be found in an env var as it denotes the end of a string.

stuff I searched to come to this solution:
https://www.man7.org/linux/man-pages/man1/env.1.html
https://stackoverflow.com/questions/8677546/reading-null-delimited-strings-through-a-bash-loop