### PR TITLE
feat: use invidious api to get healthy instances

### DIFF
--- a/credits/bsgalvan.md
+++ b/credits/bsgalvan.md
@@ -1,0 +1,3 @@
+# bsgalvan
+
+* sensible `invidious_instance` selection

--- a/docs/man/ytfzf.1
+++ b/docs/man/ytfzf.1
@@ -599,11 +599,14 @@ Supported by the scrapes youtube/Y and youtube-trending/T
 .RE
 
 .PP
-Miscelanious
+Miscellaneous
 .RS
 .TP
 .BI "\-\-ii=instance", "\-\-invidious\-instance=instance"
 Use a different invidious instance.
+.TP
+.BI "\-\-rii", "\-\-refresh\-inv-instance"
+If this flag is provided, refresh instance cache with healthy instances using Invidious API
 .TP
 .BI "\-\-channel\-link=link"
 Converts channel links from 'https://youtube.com/c/name' to 'https://youtube.com/channel/id'

--- a/ytfzf
+++ b/ytfzf
@@ -2150,7 +2150,7 @@ parse_opt () {
         f|formats) show_formats=${optarg:-1} ;;
         H|history) scrape="history" ;;
         x|history-clear) clear_hist "${optarg:-all}"; exit 0 ;;
-        S|select) interface="scripting" && is_specific_select="2" && scripting_video_count="$optarg" ;;
+        S|select) interface="scripting" && is_specific_select="1" && scripting_video_count="$optarg" ;;
         a|auto-select) [ -z "$optarg" ] || [ "$optarg" -eq 1 ] &&  interface="scripting" && is_auto_select=${optarg:-1} ;;
         A|select-all) [ -z "$optarg" ] || [ "$optarg" -eq 1 ] && interface="scripting" && is_auto_select=${optarg:-1} && scripting_video_count='$' ;;
         r|random-select) [ -z "$optarg" ] || [ "$optarg" -eq 1 ] && interface="scripting" && is_random_select=${optarg:-1} ;;

--- a/ytfzf
+++ b/ytfzf
@@ -572,28 +572,24 @@ set_vars () {
     thumbnail_quality="high"
     sub_link_count="2"
 
-    # URL for instance list sorted by type and health
-    instances_url="https://api.invidious.io/instances.json?sort_by=type,health" 
+    # URL for instance list sorted by type, health and api (ones without API do not work!)
+    instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api" 
 
     # Cache location.
-    # TODO: decide on cache interval to avoid instances.json becoming stale
     instances_file="$cache_dir/instances.json"
 
-    # If file doesn't already exist, cURL and cache it.
+    # If file doesn't already exist (or if force-refresh is requested), cURL and cache it.
+    # TODO: implement `--refresh-inv-instances` to force-refresh this list
+    # TODO: + update docs
     [ ! -f "$instances_file" ] && curl -X GET -s "$instances_url" > "$instances_file"
  
     # The pipeline does the following:
     #   - Get top 10 instance URIs
-    #   - Trim out extra symbols produced by `jq`
-    #   - Remove empty lines
+    #   - Output these on individual lines
     #   - Shuffle the list
     #   - Choose the first entry
-    invidious_instance="$(jq -r 'map(.[1] | .uri) | .[0:10]' < "$instances_file" \
-                        | tr -d '[]," ' \
-                        | sed "/^$/d" \
-                        | shuf \
-                        | head -n1)"
-
+    invidious_instance=$(jq -r 'map(.[1] | .uri) | .[:10] | join("\n")' < "$instances_file" \
+                      | shuf | head -n 1)
 
     yt_video_link_domain="https://youtube.com"
     search_sort_by="relevance" search_upload_date="" search_video_duration="" search_result_type="video" search_result_features="" search_region="US"

--- a/ytfzf
+++ b/ytfzf
@@ -2278,7 +2278,7 @@ do_an_event_function "on_post_set_vars"
 instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
 
 # Where do we put the list of healthy instances?
-instances_file="$cache_dir/instances.json"
+: "${instances_file:="$cache_dir/instances.json"}"
 
 # If file doesn't already exist (or if force-refresh is requested), cURL and cache it.
 # CHECK: implement check for force-request

--- a/ytfzf
+++ b/ytfzf
@@ -2288,7 +2288,8 @@ instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
 # TODO: update docs
 [ ! -f "$instances_file" ] ||
     [ "$refresh_inv_instances" -eq 1 ] &&
-    curl -X GET -s "$instances_url" > "$instances_file"
+    echo "Fetching list of healthy invidious instances ..." &&
+    curl -X GET -sSfo "$instances_file" "$instances_url"
 
 # The pipeline does the following:
 #   - Get top 10 instance URIs

--- a/ytfzf
+++ b/ytfzf
@@ -571,7 +571,31 @@ set_vars () {
     #this comes from invidious' api
     thumbnail_quality="high"
     sub_link_count="2"
-    invidious_instance="https://y.com.sb" yt_video_link_domain="https://youtube.com"
+
+    # URL for instance list sorted by type and health
+    instances_url="https://api.invidious.io/instances.json?sort_by=type,health" 
+
+    # Cache location.
+    # TODO: decide on cache interval to avoid instances.json becoming stale
+    instances_file="$cache_dir/instances.json"
+
+    # If file doesn't already exist, cURL and cache it.
+    [ ! -f "$instances_file" ] && curl -X GET -s "$instances_url" > "$instances_file"
+ 
+    # The pipeline does the following:
+    #   - Get top 10 instance URIs
+    #   - Trim out extra symbols produced by `jq`
+    #   - Remove empty lines
+    #   - Shuffle the list
+    #   - Choose the first entry
+    invidious_instance="$(jq -r 'map(.[1] | .uri) | .[0:10]' < "$instances_file" \
+                        | tr -d '[]," ' \
+                        | sed "/^$/d" \
+                        | shuf \
+                        | head -n1)"
+
+
+    yt_video_link_domain="https://youtube.com"
     search_sort_by="relevance" search_upload_date="" search_video_duration="" search_result_type="video" search_result_features="" search_region="US"
     pages_to_scrape="1" pages_start="1"
     nsfw="false" odysee_video_search_count="30"

--- a/ytfzf
+++ b/ytfzf
@@ -572,24 +572,6 @@ set_vars () {
     thumbnail_quality="high"
     sub_link_count="2"
 
-    # URL for instance list sorted by type, health and api (ones without API do not work!)
-    instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api" 
-
-    # Cache location.
-    instances_file="$cache_dir/instances.json"
-
-    # If file doesn't already exist (or if force-refresh is requested), cURL and cache it.
-    # TODO: implement `--refresh-inv-instances` to force-refresh this list
-    # TODO: + update docs
-    [ ! -f "$instances_file" ] && curl -X GET -s "$instances_url" > "$instances_file"
- 
-    # The pipeline does the following:
-    #   - Get top 10 instance URIs
-    #   - Output these on individual lines
-    #   - Shuffle the list
-    #   - Choose the first entry
-    invidious_instance=$(jq -r 'map(.[1] | .uri) | .[:10] | join("\n")' < "$instances_file" \
-                      | shuf | head -n 1)
 
     yt_video_link_domain="https://youtube.com"
     search_sort_by="relevance" search_upload_date="" search_video_duration="" search_result_type="video" search_result_features="" search_region="US"
@@ -2182,6 +2164,7 @@ parse_opt () {
         pages-start) pages_start="$optarg" ;;
         odysee-video-count) odysee_video_search_count="$optarg" ;;
         ii|inv-instance) invidious_instance="$optarg" ;;
+        rii|refresh-inv-instances) refresh_inv_instances=1 ;;
         i|interface) load_interface "$optarg" || die 2 "$optarg is not an interface\n" ;;
         c|scrape) scrape=$optarg ;;
         scrape+) scrape="$scrape,$optarg" ;;
@@ -2290,6 +2273,27 @@ do_an_event_function "on_post_set_vars"
 #Post opt scrape{{{
 : "${ytdl_pref:=$video_pref+$audio_pref/best/$video_pref/$audio_pref}"
 : "${shortcut_binds="Enter,double-click,${next_page_shortcut},${download_shortcut},${video_shortcut},${audio_shortcut},${detach_shortcut},${print_link_shortcut},${show_formats_shortcut},${info_shortcut},${search_again_shortcut},${custom_shortcut_binds},${custom_shortcut_binds}"}"
+
+# URL for instance list sorted by type, health and api (ones without API do not work!)
+instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
+
+# Where do we put the list of healthy instances?
+instances_file="$cache_dir/instances.json"
+
+# If file doesn't already exist (or if force-refresh is requested), cURL and cache it.
+# CHECK: implement check for force-request
+# CHECK: added --refresh-inv-instances to optargs
+# TODO: update docs
+[ ! -f "$instances_file" ] ||
+    [ "$refresh_inv_instances" -eq 1 ] &&
+    curl -X GET -s "$instances_url" > "$instances_file"
+
+# The pipeline does the following:
+#   - Get top 10 instance URIs
+#   - Output these on individual lines
+#   - Shuffle the list
+#   - Choose the first entry
+: "${invidious_instance:=$(jq -r 'map(.[1] | .uri) | .[:10] | join("\n")' < "$instances_file" | shuf | head -n 1)}"
 
 FZF_DEFAULT_OPTS="--margin=0,3,0,0 $FZF_DEFAULT_OPTS"
 

--- a/ytfzf
+++ b/ytfzf
@@ -2288,7 +2288,7 @@ instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
 # TODO: update docs
 [ ! -f "$instances_file" ] ||
     [ "$refresh_inv_instances" -eq 1 ] &&
-    echo "Fetching list of healthy invidious instances ..." &&
+    print_info "Fetching list of healthy invidious instances ...\n" &&
     curl -X GET -sSfo "$instances_file" "$instances_url"
 
 # The pipeline does the following:

--- a/ytfzf
+++ b/ytfzf
@@ -572,6 +572,8 @@ set_vars () {
     thumbnail_quality="high"
     sub_link_count="2"
 
+    # default value for instance caching if flag not provided.
+    refresh_inv_instances=0
 
     yt_video_link_domain="https://youtube.com"
     search_sort_by="relevance" search_upload_date="" search_video_duration="" search_result_type="video" search_result_features="" search_region="US"
@@ -2148,7 +2150,7 @@ parse_opt () {
         f|formats) show_formats=${optarg:-1} ;;
         H|history) scrape="history" ;;
         x|history-clear) clear_hist "${optarg:-all}"; exit 0 ;;
-        S|select) interface="scripting" && is_specific_select="1" && scripting_video_count="$optarg" ;;
+        S|select) interface="scripting" && is_specific_select="2" && scripting_video_count="$optarg" ;;
         a|auto-select) [ -z "$optarg" ] || [ "$optarg" -eq 1 ] &&  interface="scripting" && is_auto_select=${optarg:-1} ;;
         A|select-all) [ -z "$optarg" ] || [ "$optarg" -eq 1 ] && interface="scripting" && is_auto_select=${optarg:-1} && scripting_video_count='$' ;;
         r|random-select) [ -z "$optarg" ] || [ "$optarg" -eq 1 ] && interface="scripting" && is_random_select=${optarg:-1} ;;


### PR DESCRIPTION
Should fix #570.
Quick and dirty implementation of the process explained in the issue above.
I am not well versed with `jq`, so this might be a roundabout manner of doing what needs to be done!

~TODO: need to implement logic for staleness of the cached instance list.~