### PR TITLE
Fix spelling in manpages.

### DIFF
--- a/docs/man/ytfzf.1
+++ b/docs/man/ytfzf.1
@@ -181,7 +181,7 @@ This can also be set in the config file with
 Whether or not to download thumbnails asynchronously.
 .br
 Downloading asynchronously will open the menu before all thumbnails are downloaded.
-This can also be set in the config fil with
+This can also be set in the config file with
 .BR async_thumbnails .
 .TP
 .BR \-\-skip\-thumb\-download
@@ -265,7 +265,7 @@ See SORT NAMES in ytfzf(5) for more information.
 .TP
 .BR \-\-fancy\-subs
 Whether or not to have a separator between each subscription.
-When this option is used it automatically disbables \-\-sort as it will mess up this option.
+When this option is used it automatically disables \-\-sort as it will mess up this option.
 .br
 This can also be set in the config file with
 .BR fancy_subs .
@@ -651,7 +651,7 @@ This can also be set in the config file with
 .BI \-\-ytdl\-opts= option
 Pass command\-line options to youtube\-dl when downloading.
 .EX
-.RB "example: " \-\-ytdl\-opts= "\fI\'\-o ~/Videos/%(title)s.%(ext)s\'"
+.RB "example: " \-\-ytdl\-opts= "\fI\"\-o ~/Videos/%(title)s.%(ext)s\""
 .EE
 .TP
 .BI \-\-ytdl\-path= path
@@ -839,7 +839,7 @@ An explanation of each directory/file:
 .IR searches.lsit
 A list of all searches
 .br
-If \-\-multi\-search is enabled, each search is seperated by a new line
+If \-\-multi\-search is enabled, each search is separated by a new line
 .TP
 .IR watch_hist
 The watch history file.
@@ -859,7 +859,7 @@ Created when a submenu is opened (eg: when a channel/playlist is selected).
 Stores the thumbnails for the instance (only with \-t).
 .TP
 .IR tmp
-Stores less importatnt temporarily used files.
+Stores less important temporarily used files.
 .TP
 .IR curl_config
 The configuration file for curl for downloading thumbnails (only with \-t).

--- a/docs/man/ytfzf.5
+++ b/docs/man/ytfzf.5
@@ -503,7 +503,9 @@ Currently only applies to the comments scrape.
 .RB $ shortcut_binds
 The keys to listen for in fzf.
 .br
-.IR default: " Enter,double-click,$next_page_shortcut,$download_shortcut,$video_shortcut,$detach_shortcut,$print_link_shortcut,$show_formats_shortcut,$info_shortcut,$search_again_shortcut,$custom_shortcut_binds"
+.IR default: " Enter,double-click,$next_page_shortcut,$download_shortcut,
+$video_shortcut,$detach_shortcut,$print_link_shortcut,$show_formats_shortcut,
+$info_shortcut,$search_again_shortcut,$custom_shortcut_binds"
 
 .TP
 .RB $ custom_shortcut_binds
@@ -608,7 +610,7 @@ The attribute to sort by when searching.
 .TP
 .IR oldest_first " (odysee only)"
 .TP
-.IR view_count " (youtbe only)"
+.IR view_count " (youtube only)"
 .RE
 
 .TP
@@ -1388,7 +1390,7 @@ The raw optarg
 
 .TP
 .BR on_post_set_vars ()
-This fnction gets called after all vars are set, and all opts are parsed.
+This function gets called after all vars are set, and all opts are parsed.
 .br
 This function takes no arguments.
 


### PR DESCRIPTION
Follows fix spelling in the manual files according to the packaging in Debian, because I am the maintainer of the package in Debian.