### PR TITLE
Make the Makefile 'all' target phony and default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,14 @@ BINDIR=${PREFIX}/bin
 DOCDIR=${PREFIX}/share/doc/ytfzf
 MANDIR=${PREFIX}/share/man
 LICENSEDIR=${PREFIX}/share/licenses/ytfzf
+
 YTFZF_SYSTEM_ADDON_DIR=${PREFIX}/share/ytfzf/addons
 
-all: install doc
+.DEFAULT_GOAL := default
+
+all:
+
+default: install doc
 
 doc:
 	mkdir -p ${DESTDIR}${MANDIR}/man1
@@ -48,4 +53,4 @@ uninstall-old:
 	rm -f /usr/share/man/man1/ytfzf.1*
 	rm -f /usr/share/man/man5/ytfzf.5*
 
-.PHONY: all install uninstall doc addons uninstall-old
+.PHONY: all default install uninstall doc addons uninstall-old

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,9 @@ BINDIR=${PREFIX}/bin
 DOCDIR=${PREFIX}/share/doc/ytfzf
 MANDIR=${PREFIX}/share/man
 LICENSEDIR=${PREFIX}/share/licenses/ytfzf
-
 YTFZF_SYSTEM_ADDON_DIR=${PREFIX}/share/ytfzf/addons
 
-all:
+all: install doc
 
 doc:
 	mkdir -p ${DESTDIR}${MANDIR}/man1
@@ -49,4 +48,4 @@ uninstall-old:
 	rm -f /usr/share/man/man1/ytfzf.1*
 	rm -f /usr/share/man/man5/ytfzf.5*
 
-.PHONY: install uninstall doc addons uninstall-old
+.PHONY: all install uninstall doc addons uninstall-old

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ There are only 2 required dependencies, however the rest require some configurat
 ```sh
 git clone https://github.com/pystardust/ytfzf
 cd ytfzf
-sudo make 
+sudo make install doc
 ```
 
 * If you wish to not install documentation (highly unrecommended) run `sudo make install` instead.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ There are only 2 required dependencies, however the rest require some configurat
 ```sh
 git clone https://github.com/pystardust/ytfzf
 cd ytfzf
-sudo make install doc
+sudo make 
 ```
 
 * If you wish to not install documentation (highly unrecommended) run `sudo make install` instead.


### PR DESCRIPTION
![`make` it so](https://media.giphy.com/media/wNlks0ID1igO4/giphy.gif)

I noticed in the README, we are encouraging users to include the docs by default.

I also noticed the makefile had an empty `all` target. GNU `make`, when invoked without an explicit target, will snag the first one it finds.

This PR simply adds the default `install` and `doc` targets the default. I updated the README to reflect this as well.

