### PR TITLE
Add required whitespace to vim modeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,8 @@ assignees: ''
  - OS:
  - Terminal:
  - Ytfzf version:
-- Output of `ls -l "$(which sh)"` (if your using fish: `ls -l (which sh)`):
+- Output of `ls -l "$(which sh)"` (if you're using fish: `ls -l (which sh)`):
+ - (if is a thumbnail issue) run `ytfzf --thumbnail-log=log.txt` and post the file:
 
 
 ### Additional context

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,11 @@ LICENSEDIR=${PREFIX}/share/licenses/ytfzf
 
 YTFZF_SYSTEM_ADDON_DIR=${PREFIX}/share/ytfzf/addons
 
+.DEFAULT_GOAL := default
+
 all:
+
+default: install doc
 
 doc:
 	mkdir -p ${DESTDIR}${MANDIR}/man1

--- a/addons/scrapers/ani-category
+++ b/addons/scrapers/ani-category
@@ -18,7 +18,7 @@ _decrypt_link() {
 _get_video_link () {
 	dpage_url="$1"
 	video_links=$(_decrypt_link "$dpage_url")
-	if printf '%s' "$video_links" | grep -q "mp4"; then 
+	if printf '%s' "$video_links" | grep -q "mp4"; then
 		video_url=$(printf "%s" "$video_links" | head -n 4 | tail -n 1)
 		idx=1
 	else
@@ -104,7 +104,7 @@ scrape_ani_category () {
 	    _get_video_link "$dpage_link"
 	    echo "[]" | jq --arg idx "$idx" --arg dpage "$dpage_link" --arg url "$video_url" --arg title "$search episode $ep_start" '[{"url": $url, "title": $title, "ID": $title, "idx": $idx, "dpage": $dpage}]' > "$_tmp_json"
 	} &
-	: $((ep_start+=1))
+	ep_start=$((ep_start+1))
 	_thread_started "$!"
     done
     wait

--- a/credits/bsgalvan.md
+++ b/credits/bsgalvan.md
@@ -1,0 +1,3 @@
+# bsgalvan
+
+* sensible `invidious_instance` selection

--- a/docs/man/ytfzf.1
+++ b/docs/man/ytfzf.1
@@ -61,11 +61,6 @@ Play audio only.
 This can also be set in the config file with
 .BR is_audio_only .
 .TP
-.BR \-\-fullscreen
-Tell the url handler to play in fullscreen mode.
-This can also be set in the config file with
-.BR is_fullscreen .
-.TP
 .BR \-f ", " \-\-formats
 Show available formats before proceeding.
 .TP

--- a/docs/man/ytfzf.1
+++ b/docs/man/ytfzf.1
@@ -608,6 +608,9 @@ Use a different invidious instance.
 .BI "\-\-rii", "\-\-refresh\-inv-instance"
 If this flag is provided, refresh instance cache with healthy instances using Invidious API
 .TP
+.BI "\-\-available\-inv\-instances"
+Prints the invidious instances that may be used and exits.
+.TP
 .BI "\-\-channel\-link=link"
 Converts channel links from 'https://youtube.com/c/name' to 'https://youtube.com/channel/id'
 .TP

--- a/docs/man/ytfzf.1
+++ b/docs/man/ytfzf.1
@@ -599,11 +599,14 @@ Supported by the scrapes youtube/Y and youtube-trending/T
 .RE
 
 .PP
-Miscelanious
+Miscellaneous
 .RS
 .TP
 .BI "\-\-ii=instance", "\-\-invidious\-instance=instance"
 Use a different invidious instance.
+.TP
+.BI "\-\-rii", "\-\-refresh\-inv-instance"
+If this flag is provided, refresh instance cache with healthy instances using Invidious API
 .TP
 .BI "\-\-channel\-link=link"
 Converts channel links from 'https://youtube.com/c/name' to 'https://youtube.com/channel/id'

--- a/docs/man/ytfzf.1
+++ b/docs/man/ytfzf.1
@@ -667,6 +667,11 @@ to your config file.
 .TP
 .BI \-\-list\-addons
 Lists all addons and exits.
+.TP
+.BI \-\-thumbnail\-log
+Sets the file to log thumbnail debug info to.
+This can also be set in the config file with
+.BR thumbnail_debug_log .
 .RE
 
 .SH CONFIGURATION

--- a/docs/man/ytfzf.5
+++ b/docs/man/ytfzf.5
@@ -801,6 +801,11 @@ Log only errors
 .RE
 
 .TP
+.RB $ thumbnail_debug_log
+The log file for thumbnail debug information.
+.IR default: "/dev/null"
+
+.TP
 .RB $ useragent
 The useragent to use when scraping websites.
 .br

--- a/docs/man/ytfzf.5
+++ b/docs/man/ytfzf.5
@@ -125,12 +125,6 @@ Whether or not to only play audio.
 .IR default: " 0"
 
 .TP
-.RB $ is_fullscreen
-Whether or not to play in fullscreen mode.
-.br
-.IR default: " 0"
-
-.TP
 .RB $ url_handler
 The function/programs to handle the selected videos
 .br

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="git-1699.5af0c73"
+YTFZF_VERSION="git-1701.099ba9a"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID
@@ -528,7 +528,7 @@ set_vars () {
     search_source=args:prompt
 
     # debugging
-    log_level="2"
+    log_level="2" thumbnail_debug_log="/dev/null"
 
     # scraping
     useragent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36"
@@ -1696,13 +1696,13 @@ preview_start () {
 			rm -f "$UEBERZUG_FIFO"
 			mkfifo "$UEBERZUG_FIFO"
 			ueberzug layer --parser json < "$UEBERZUG_FIFO"  &
-			exec 3> "$UEBERZUG_FIFO" # to keep the fifo open
+			exec 3> "$UEBERZUG_FIFO" > "$thumbnail_debug_log" 2>&1 # to keep the fifo open
 			;;
 		chafa|chafa-16|chafa-tty|catimg|catimg-256|swayimg) : ;;
 		kitty) command_exists "kitty" || die 3 "kitty is not installed\n" ;;
 		imv)
 			first_img="$(jq -r '.[0].ID|select(.!=null)' < "$ytfzf_video_json_file")"
-			imv "$thumb_dir/${first_img}.jpg" &
+			imv "$thumb_dir/${first_img}.jpg" > "$thumbnail_debug_log" 2>&1 &
 			export imv_pid="$!"
 			#helps prevent imv seg fault
 			sleep 0.1
@@ -1713,7 +1713,7 @@ preview_start () {
 			first_img="$(jq -r '.[0].ID|select(.!=null)' < "$ytfzf_video_json_file")"
 			export MPV_SOCKET="$session_temp_dir/mpv.socket"
 			rm -f "$MPV_SOCKET" > /dev/null 2>&1
-			mpv --input-ipc-server="$MPV_SOCKET" --loop-file=inf --idle=yes "$thumb_dir/${first_img}.jpg" > /dev/null 2>&1 &
+			mpv --input-ipc-server="$MPV_SOCKET" --loop-file=inf --idle=yes "$thumb_dir/${first_img}.jpg" > "$thumbnail_debug_log" 2>&1 &
 			export mpv_pid=$!
 			;;
 		*)
@@ -1878,7 +1878,7 @@ preview_display_image () {
 			'width' "$width"
 		    printf '"%s": "%s"' 'height' "$height"
 		    printf "}\n"
-		} > "$UEBERZUG_FIFO"
+		} > "$UEBERZUG_FIFO" 2> "$thumbnail_debug_log"
 		;;
 	    swayimg)
             _swayimg_pid_file="${session_temp_dir}/_swayimg.pid"
@@ -1911,40 +1911,40 @@ EOF
 
             get_swayimg_positioning "$((w))" "$((h))" "$x" "$y" "$col_px_width" "$line_px_height"
             swaymsg 'no_focus [app_id="swayimg_.*"]' > /dev/null 2>&1
-            swayimg -s fit -g $x,$y,$((img_w)),$((img_h)) "$thumb_path"  2> /dev/null >&2 &
+            swayimg -s fit -g $x,$y,$((img_w)),$((img_h)) "$thumb_path"  2> "$thumbnail_debug_log" >&2 &
             printf "%s" "$!" > "$_swayimg_pid_file"
             #without this there are weird flushing issues (maybe)
             echo ;;
 	    chafa)
 		printf '\n'
 		command_exists "chafa" || die 3 "\nchafa is not installed\n"
-            chafa --format=symbols -s "$((width-4))x$height" "$thumb_path" ;;
+            chafa --format=symbols -s "$((width-4))x$height" "$thumb_path" 2> "$thumbnail_debug_log";;
 	    chafa-16)
 		    printf '\n'
 		    command_exists "chafa" || die 3 "\nchafa is not installed\n"
-		    chafa --format=symbols -c 240 -s "$((width-2))x$((height-10))" "$thumb_path" ;;
+		    chafa --format=symbols -c 240 -s "$((width-2))x$((height-10))" "$thumb_path" 2> "$thumbnail_debug_log" ;;
 	    chafa-tty)
 		    printf '\n'
 		    command_exists "chafa" || die 3 "\nchafa is not installed\n"
-		    chafa --format=symbols -c 16 -s "$((width-2))x$((height-10))" "$thumb_path" ;;
+		    chafa --format=symbols -c 16 -s "$((width-2))x$((height-10))" "$thumb_path" "$thumbnail_debug_log" ;;
 	    catimg)
 		    printf '\n'
 		    command_exists "catimg" || die 3 "\ncatimg is not installed\n"
-		    catimg -w "$width" "$thumb_path" ;;
+		    catimg -w "$width" "$thumb_path" 2> "$thumbnail_debug_log" ;;
 	    catimg-256)
 		    printf '\n'
 		    command_exists "catimg" || die 3 "\ncatimg is not installed\n"
-		    catimg -c -w "$width" "$thumb_path" ;;
+		    catimg -c -w "$width" "$thumb_path" 2> "$thumbnail_debug_log" ;;
 	    imv)
-		    imv-msg "$imv_pid" open "$thumb_path"
-		    imv-msg "$imv_pid" next
+		    imv-msg "$imv_pid" open "$thumb_path" 2> "$thumbnail_debug_log" >&2
+		    imv-msg "$imv_pid" next 2> "$thumbnail_debug_log" >&2
 		    ;;
 	    mpv)
-		    echo "loadfile '$thumb_path'" | socat - "$MPV_SOCKET" ;;
+		    echo "loadfile '$thumb_path'" | socat - "$MPV_SOCKET" > "$thumbnail_debug_log" 2>&1 ;;
 	    kitty)
 		get_ueberzug_positioning "$FZF_PREVIEW_COLUMNS" "$FZF_PREVIEW_LINES" "$fzf_preview_side"
-		kitty +kitten icat --clear --transfer-mode file
-		kitty +kitten icat --place "${width}x${height}@${x}x${y}" --scale-up --transfer-mode file "$thumb_path" ;;
+		kitty +kitten icat --clear --transfer-mode file > "$thumbnail_debug_log" 2>&1
+		kitty +kitten icat --place "${width}x${height}@${x}x${y}" --scale-up --transfer-mode file "$thumb_path" > "$thumbnail_debug_log" 2>&1 ;;
 	    *)
 		get_ueberzug_positioning "$FZF_PREVIEW_COLUMNS" "$FZF_PREVIEW_LINES" "$fzf_preview_side"
 		"$thumbnail_viewer" "view" "$thumb_path" "$x" "$y" "$width" "$height" "$FZF_PREVIEW_COLUMNS" "$FZF_PREVIEW_LINES" "$fzf_preview_side";;
@@ -2213,6 +2213,7 @@ parse_opt () {
         q|search-hist) [ ! -s "$search_hist_file" ] && die 1 "You have no search history\n"a; search_source="hist:$search_source" ;;
         pages) pages_to_scrape="$optarg" ;;
         pages-start) pages_start="$optarg" ;;
+        thumbnail-log) thumbnail_debug_log="${optarg:-/dev/stderr}" ;;
         odysee-video-count) odysee_video_search_count="$optarg" ;;
         ii|inv-instance) invidious_instance="$optarg" ;;
         rii|refresh-inv-instances) refresh_inv_instances ;;

--- a/ytfzf
+++ b/ytfzf
@@ -2278,6 +2278,8 @@ do_an_event_function "on_post_set_vars"
 # files
 : "${hist_file:="$cache_dir/watch_hist"}" "${search_hist_file:="$cache_dir/search_hist"}"
 
+[ ! -d "$cache_dir" ] && mkdir -p "$cache_dir"
+
 # Where do we put the list of healthy instances?
 : "${instances_file:="$cache_dir/instances.json"}"
 

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="git-1693.58f95b9"
+YTFZF_VERSION="git-1694.850099b"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="git-1694.850099b"
+YTFZF_VERSION="git-1695.ef968e6"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID

--- a/ytfzf
+++ b/ytfzf
@@ -571,7 +571,11 @@ set_vars () {
     #this comes from invidious' api
     thumbnail_quality="high"
     sub_link_count="2"
-    invidious_instance="https://y.com.sb" yt_video_link_domain="https://youtube.com"
+
+    # default value for instance caching if flag not provided.
+    refresh_inv_instances=0
+
+    yt_video_link_domain="https://youtube.com"
     search_sort_by="relevance" search_upload_date="" search_video_duration="" search_result_type="video" search_result_features="" search_region="US"
     pages_to_scrape="1" pages_start="1"
     nsfw="false" odysee_video_search_count="30"
@@ -2162,6 +2166,7 @@ parse_opt () {
         pages-start) pages_start="$optarg" ;;
         odysee-video-count) odysee_video_search_count="$optarg" ;;
         ii|inv-instance) invidious_instance="$optarg" ;;
+        rii|refresh-inv-instances) refresh_inv_instances=1 ;;
         i|interface) load_interface "$optarg" || die 2 "$optarg is not an interface\n" ;;
         c|scrape) scrape=$optarg ;;
         scrape+) scrape="$scrape,$optarg" ;;
@@ -2270,6 +2275,28 @@ do_an_event_function "on_post_set_vars"
 #Post opt scrape{{{
 : "${ytdl_pref:=$video_pref+$audio_pref/best/$video_pref/$audio_pref}"
 : "${shortcut_binds="Enter,double-click,${next_page_shortcut},${download_shortcut},${video_shortcut},${audio_shortcut},${detach_shortcut},${print_link_shortcut},${show_formats_shortcut},${info_shortcut},${search_again_shortcut},${custom_shortcut_binds},${custom_shortcut_binds}"}"
+
+# URL for instance list sorted by type, health and api (ones without API do not work!)
+instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
+
+# Where do we put the list of healthy instances?
+: "${instances_file:="$cache_dir/instances.json"}"
+
+# If file doesn't already exist (or if force-refresh is requested), cURL and cache it.
+# CHECK: implement check for force-request
+# CHECK: added --refresh-inv-instances to optargs
+# TODO: update docs
+[ ! -f "$instances_file" ] ||
+    [ "$refresh_inv_instances" -eq 1 ] &&
+    print_info "Fetching list of healthy invidious instances ...\n" &&
+    curl -X GET -sSfo "$instances_file" "$instances_url"
+
+# The pipeline does the following:
+#   - Get top 10 instance URIs
+#   - Output these on individual lines
+#   - Shuffle the list
+#   - Choose the first entry
+: "${invidious_instance:=$(jq -r 'map(.[1] | .uri) | .[:10] | join("\n")' < "$instances_file" | shuf | head -n 1)}"
 
 FZF_DEFAULT_OPTS="--margin=0,3,0,0 $FZF_DEFAULT_OPTS"
 

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="git-1697.033cae7"
+YTFZF_VERSION="git-1697.b71429e"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID
@@ -1860,12 +1860,18 @@ preview_display_image () {
             _swayimg_pid_file="${session_temp_dir}/_swayimg.pid"
             [ -f "$_swayimg_pid_file" ] && kill "$(cat "$_swayimg_pid_file")" 2> /dev/null
             command_exists "tput" || die 3 "tput is required for this viewer\n(you are probably missing ncurses)\n"
-            read -r x y w h term_pid <<-EOF
-$(swaymsg -t get_tree | jq -r '..|try select(.focused==true)|[.rect.x,.rect.y,.rect.width,.rect.height,.pid]|@tsv')
-EOF
-            focused_id=$(swaymsg -t get_tree| jq -r '.focus[0]')
-            read -r output_x output_y <<-EOF
-$(swaymsg -t get_tree | jq -r '..|try select(.type=="output" and .id=='"$focused_id"')|[.rect.x,.rect.y]|@tsv')
+            #this jq call finds the id of the selected monitor and saves it as $focused_id
+            #then finds x, and y of the focused monitor and saves it as the var $d1
+            #then it finds the geometry of the focused window and saves it as the var $d2
+            #at the end it concatinates the two strings with a tab in the middle so that read can read it into 6 vars
+            read -r output_x output_y x y w h <<-EOF
+$(swaymsg -t get_tree | jq -r '. as $data |
+    .focus[0] as $focused_id |
+    ..| try select(.type=="output" and .id==$focused_id) |
+    [.rect.x,.rect.y] | @tsv as $d1 |
+    $data | .. | try select(.focused==true) |
+    [.rect.x,.rect.y,.rect.width,.rect.height] | @tsv as $d2 |
+    $d1 + "\t" + $d2')
 EOF
             #we're subtracting output_* to make sure swayimg places on correct monitor
             x=$((x-output_x))
@@ -1880,11 +1886,10 @@ EOF
             line_px_height=$((h/TTY_LINES))
 
             get_swayimg_positioning "$((w))" "$((h))" "$x" "$y" "$col_px_width" "$line_px_height"
+            swaymsg 'no_focus [app_id="swayimg_.*"]' > /dev/null 2>&1
             swayimg -s fit -g $x,$y,$((img_w)),$((img_h)) "$thumb_path"  2> /dev/null >&2 &
             printf "%s" "$!" > "$_swayimg_pid_file"
-            sleep 0.1
-            swaymsg "[pid=\"$term_pid\"]" focus > /dev/null 2>&1
-            #without this there are weird flushing issues
+            #without this there are weird flushing issues (maybe)
             echo ;;
 	    chafa)
 		printf '\n'

--- a/ytfzf
+++ b/ytfzf
@@ -2590,4 +2590,4 @@ while [ "$search_again" -eq 1 ] ; do
 done
 #}}}
 
-#vim:foldmethod=marker:shiftwidth=4:tabstop=4
+# vim: foldmethod=marker:shiftwidth=4:tabstop=4

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="2.5.0"
+YTFZF_VERSION="git-1692.d5ff2ed"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID
@@ -1854,32 +1854,35 @@ preview_display_image () {
 		} > "$UEBERZUG_FIFO"
 		;;
 	    swayimg)
-		command_exists "tput" || die 3 "tput is required for this viewer\n(you are probably missing ncurses)\n"
-		read -r x y w h term_pid <<-EOF
+            _swayimg_pid_file="${session_temp_dir}/_swayimg.pid"
+            [ -f "$_swayimg_pid_file" ] && kill "$(cat "$_swayimg_pid_file")" 2> /dev/null
+            command_exists "tput" || die 3 "tput is required for this viewer\n(you are probably missing ncurses)\n"
+            read -r x y w h term_pid <<-EOF
 $(swaymsg -t get_tree | jq -r '..|try select(.focused==true)|[.rect.x,.rect.y,.rect.width,.rect.height,.pid]|@tsv')
 EOF
-		focused_id=$(swaymsg -t get_tree| jq -r '.focus[0]')
-		read -r output_x output_y <<-EOF
+            focused_id=$(swaymsg -t get_tree| jq -r '.focus[0]')
+            read -r output_x output_y <<-EOF
 $(swaymsg -t get_tree | jq -r '..|try select(.type=="output" and .id=='"$focused_id"')|[.rect.x,.rect.y]|@tsv')
 EOF
-		#we're subtracting output_* to make sure swayimg places on correct monitor
-		x=$((x-output_x))
-		y=$((y-output_y))
-		TTY_COLS=$(tput cols)
-		TTY_LINES=$(tput lines)
-		#shellcheck disable=SC2034
-		w_half=$((w/2)) h_half=$((h/2))
-		#how many pixels per col
-		col_px_width=$((w/TTY_COLS))
-		#how many pixels per line
-		line_px_height=$((h/TTY_LINES))
+            #we're subtracting output_* to make sure swayimg places on correct monitor
+            x=$((x-output_x))
+            y=$((y-output_y))
+            TTY_COLS=$(tput cols)
+            TTY_LINES=$(tput lines)
+            #shellcheck disable=SC2034
+            w_half=$((w/2)) h_half=$((h/2))
+            #how many pixels per col
+            col_px_width=$((w/TTY_COLS))
+            #how many pixels per line
+            line_px_height=$((h/TTY_LINES))
 
-		get_swayimg_positioning "$((w))" "$((h))" "$x" "$y" "$col_px_width" "$line_px_height"
-		swayimg -s fit -g $x,$y,$((img_w)),$((img_h)) "$thumb_path"  2> /dev/null >&2 &
-		sleep 0.1
-		swaymsg "[pid=\"$term_pid\"]" focus > /dev/null 2>&1
-		#without this there are weird flushing issues
-		echo ;;
+            get_swayimg_positioning "$((w))" "$((h))" "$x" "$y" "$col_px_width" "$line_px_height"
+            swayimg -s fit -g $x,$y,$((img_w)),$((img_h)) "$thumb_path"  2> /dev/null >&2 &
+            printf "%s" "$!" > "$_swayimg_pid_file"
+            sleep 0.1
+            swaymsg "[pid=\"$term_pid\"]" focus > /dev/null 2>&1
+            #without this there are weird flushing issues
+            echo ;;
 	    chafa)
 		printf '\n'
 		command_exists "chafa" || die 3 "\nchafa is not installed\n"
@@ -1970,7 +1973,7 @@ interface_thumbnails () {
 	jq -r '.[]|[.title,"'"$gap_space"'|"+.channel,"|"+.duration,"|"+.views,"|"+.date,"|"+.url]|join("\t")' < "$video_json_file" |
 	sort_video_data_fn |
 	SHELL="$(command -v sh)" fzf -m \
-	--preview "__is_fzf_preview=1 fzf_preview_side='$fzf_preview_side' scrape='$scrape' thumb_dir='$thumb_dir' YTFZF_PID='$YTFZF_PID' UEBERZUG_FIFO='$UEBERZUG_FIFO' $0 -U preview_img '$thumbnail_viewer' {} '$video_json_file'" \
+	--preview "__is_fzf_preview=1 fzf_preview_side='$fzf_preview_side' scrape='$scrape' thumb_dir='$thumb_dir' session_cache_dir='$session_cache_dir' session_temp_dir='$session_temp_dir' YTFZF_PID='$YTFZF_PID' UEBERZUG_FIFO='$UEBERZUG_FIFO' $0 -U preview_img '$thumbnail_viewer' {} '$video_json_file'" \
 	--preview-window "$fzf_preview_side:50%:wrap" --layout=reverse --expect="$shortcut_binds" | set_keypress |
 	trim_url > "$selected_id_file"
 
@@ -2260,7 +2263,6 @@ _getopts () {
 			    case $1 in
 				    preview_img)
 					    #shellcheck disable=SC2031
-					    session_cache_dir=$cache_dir/$SEARCH_PREFIX-$YTFZF_PID
 					    shift
 					    source_scrapers
 					    preview_img "$@"

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="git-1695.ef968e6"
+YTFZF_VERSION="git-1697.033cae7"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID
@@ -2423,7 +2423,7 @@ handle_scraping (){
     for curr_scrape in $scrape; do
         __scrape_count=$((__scrape_count+1))
         [ "$multi_search" -eq 1 ] && get_search_from_source "next"
-        do_an_event_function "on_search" "$_search" "$curr_scrape"
+        do_an_event_function "ext_on_search" "$_search" "$curr_scrape"
         command_exists "on_search_$_search" && "on_search_$_search" "$curr_scrape"
         "scrape_$(printf '%s' "$curr_scrape" | sed 's/-/_/g')" "$_search" "$ytfzf_video_json_file"
         handle_scrape_error "$?" "$curr_scrape"

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="2.5.0.rc-5"
+YTFZF_VERSION="2.5.0"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID

--- a/ytfzf
+++ b/ytfzf
@@ -48,7 +48,7 @@ choose_invidious_instance () {
     #   - Output these on individual lines
     #   - Shuffle the list
     #   - Choose the first entry
-    jq -r 'map(.[1] | .uri) | .[:10] | join("\n")' < "$instances_file" | shuf | head -n 1
+    jq -r '[.[]|select(.[1].api==true)|.[1].uri]|.[:10]|join("\n")' < "$instances_file" | shuf | head -n 1
 }
 
 run_interface () {

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="git-1692.d5ff2ed"
+YTFZF_VERSION="git-1693.58f95b9"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID
@@ -40,15 +40,14 @@ refresh_inv_instances () {
         curl -X GET -sSfo "$instances_file" "$instances_url"
 }
 
-choose_invidious_instance () {
+get_invidious_instances () {
     # URL for instance list sorted by type, health and api (ones without API do not work!)
-    instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
     # The pipeline does the following:
     #   - Get top 10 instance URIs
     #   - Output these on individual lines
     #   - Shuffle the list
     #   - Choose the first entry
-    jq -r '[.[]|select(.[1].api==true)|.[1].uri]|.[:10]|join("\n")' < "$instances_file" | shuf | head -n 1
+    jq -r '[.[]|select(.[1].api==true)|.[1].uri]|.[:10]|join("\n")' < "$instances_file"
 }
 
 run_interface () {
@@ -646,6 +645,10 @@ done
 #shellcheck disable=SC1090
 [ -f "$YTFZF_CONFIG_FILE" ] && . "$YTFZF_CONFIG_FILE"
 
+# files, and const vars
+: "${hist_file:="$cache_dir/watch_hist"}" "${search_hist_file:="$cache_dir/search_hist"}" : "${instances_file:="$cache_dir/instances.json"}"
+
+instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
 
 # urlhandlers
 #job of url handlers is:
@@ -2211,6 +2214,7 @@ parse_opt () {
         features) search_result_features=$optarg ;;
         region) search_region=$optarg ;;
         channel-link) _get_real_channel_link "$optarg"; exit 0 ;;
+        available-inv-instances) get_invidious_instances; exit 0 ;;
         disable-submenus) enable_submenus="${optarg:-0}" ;;
         thumbnail-quality) thumbnail_quality="$optarg" ;;
         u|url-handler)  load_url_handler "$optarg";;
@@ -2290,8 +2294,6 @@ do_an_event_function "on_post_set_vars"
 : "${shortcut_binds="Enter,double-click,${next_page_shortcut},${download_shortcut},${video_shortcut},${audio_shortcut},${detach_shortcut},${print_link_shortcut},${show_formats_shortcut},${info_shortcut},${search_again_shortcut},${custom_shortcut_binds},${custom_shortcut_binds}"}"
 
 
-# files
-: "${hist_file:="$cache_dir/watch_hist"}" "${search_hist_file:="$cache_dir/search_hist"}" : "${instances_file:="$cache_dir/instances.json"}"
 
 [ ! -d "$cache_dir" ] && mkdir -p "$cache_dir"
 
@@ -2300,7 +2302,7 @@ do_an_event_function "on_post_set_vars"
 # CHECK: added --refresh-inv-instances to optargs
 [ ! -f "$instances_file" ] && refresh_inv_instances
 
-: "${invidious_instance:=$(choose_invidious_instance)}"
+: "${invidious_instance:=$(get_invidious_instances | shuf | head -n 1)}"
 
 
 FZF_DEFAULT_OPTS="--margin=0,3,0,0 $FZF_DEFAULT_OPTS"

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="git-1697.b71429e"
+YTFZF_VERSION="git-1698.cd09e5e"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID
@@ -2036,12 +2036,15 @@ handle_info_wait_action () {
 submenu_handler () {
 	#eat stdin and close it
 	cat > /dev/null
+    old_interface="$interface"
 	[ "$keep_vars" -eq 0 ] && set_vars 0
 	search="$(get_key_value "$_submenu_actions" "search")"
 	__scrape="$(get_key_value "$_submenu_actions" "type")"
 	submenu_opts="$old_submenu_scraping_opts -c${__scrape} $old_submenu_opts"
 	#this needs to be here as well as close_url_handler because it will not happen inside this function if it's not here
 	url_handler="$old_url_handler"
+    interface="$old_interface"
+    unset old_interface
 	(
 	    #shellcheck disable=2030
 	    export __is_submenu=1

--- a/ytfzf
+++ b/ytfzf
@@ -35,6 +35,22 @@ c_bold="\033[1m"
 
 # Utility functions {{{
 
+refresh_inv_instances () {
+    print_info "Fetching list of healthy invidious instances ...\n" &&
+        curl -X GET -sSfo "$instances_file" "$instances_url"
+}
+
+choose_invidious_instance () {
+    # URL for instance list sorted by type, health and api (ones without API do not work!)
+    instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
+    # The pipeline does the following:
+    #   - Get top 10 instance URIs
+    #   - Output these on individual lines
+    #   - Shuffle the list
+    #   - Choose the first entry
+    jq -r 'map(.[1] | .uri) | .[:10] | join("\n")' < "$instances_file" | shuf | head -n 1
+}
+
 run_interface () {
     _interface="interface_${interface:-text}"
     $(printf "%s" "$_interface" | sed 's/-/_/g') "$ytfzf_video_json_file" "$ytfzf_selected_urls"
@@ -569,9 +585,6 @@ set_vars () {
     #this comes from invidious' api
     thumbnail_quality="high"
     sub_link_count="2"
-
-    # default value for instance caching if flag not provided.
-    refresh_inv_instances=0
 
     yt_video_link_domain="https://youtube.com"
     search_sort_by="relevance" search_upload_date="" search_video_duration="" search_result_type="video" search_result_features="" search_region="US"
@@ -2164,7 +2177,7 @@ parse_opt () {
         pages-start) pages_start="$optarg" ;;
         odysee-video-count) odysee_video_search_count="$optarg" ;;
         ii|inv-instance) invidious_instance="$optarg" ;;
-        rii|refresh-inv-instances) refresh_inv_instances=1 ;;
+        rii|refresh-inv-instances) refresh_inv_instances ;;
         i|interface) load_interface "$optarg" || die 2 "$optarg is not an interface\n" ;;
         c|scrape) scrape=$optarg ;;
         scrape+) scrape="$scrape,$optarg" ;;
@@ -2276,30 +2289,17 @@ do_an_event_function "on_post_set_vars"
 
 
 # files
-: "${hist_file:="$cache_dir/watch_hist"}" "${search_hist_file:="$cache_dir/search_hist"}"
+: "${hist_file:="$cache_dir/watch_hist"}" "${search_hist_file:="$cache_dir/search_hist"}" : "${instances_file:="$cache_dir/instances.json"}"
 
 [ ! -d "$cache_dir" ] && mkdir -p "$cache_dir"
-
-# Where do we put the list of healthy instances?
-: "${instances_file:="$cache_dir/instances.json"}"
-
-# URL for instance list sorted by type, health and api (ones without API do not work!)
-instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
 
 # If file doesn't already exist (or if force-refresh is requested), cURL and cache it.
 # CHECK: implement check for force-request
 # CHECK: added --refresh-inv-instances to optargs
-[ ! -f "$instances_file" ] ||
-    [ "$refresh_inv_instances" -eq 1 ] &&
-    print_info "Fetching list of healthy invidious instances ...\n" &&
-    curl -X GET -sSfo "$instances_file" "$instances_url"
+[ ! -f "$instances_file" ] && refresh_inv_instances
 
-# The pipeline does the following:
-#   - Get top 10 instance URIs
-#   - Output these on individual lines
-#   - Shuffle the list
-#   - Choose the first entry
-: "${invidious_instance:=$(jq -r 'map(.[1] | .uri) | .[:10] | join("\n")' < "$instances_file" | shuf | head -n 1)}"
+: "${invidious_instance:=$(choose_invidious_instance)}"
+
 
 FZF_DEFAULT_OPTS="--margin=0,3,0,0 $FZF_DEFAULT_OPTS"
 

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="git-1701.099ba9a"
+YTFZF_VERSION="git-1701.6de5a82"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="2.5.0.rc-4"
+YTFZF_VERSION="2.5.0.rc-5"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID
@@ -545,8 +545,6 @@ set_vars () {
     # directories
     cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/ytfzf" keep_cache="0"
 
-    # files
-    hist_file="$cache_dir/watch_hist" search_hist_file="$cache_dir/search_hist"
 
     # history
     enable_hist="1" enable_search_hist="1"
@@ -2276,16 +2274,19 @@ do_an_event_function "on_post_set_vars"
 : "${ytdl_pref:=$video_pref+$audio_pref/best/$video_pref/$audio_pref}"
 : "${shortcut_binds="Enter,double-click,${next_page_shortcut},${download_shortcut},${video_shortcut},${audio_shortcut},${detach_shortcut},${print_link_shortcut},${show_formats_shortcut},${info_shortcut},${search_again_shortcut},${custom_shortcut_binds},${custom_shortcut_binds}"}"
 
-# URL for instance list sorted by type, health and api (ones without API do not work!)
-instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
+
+# files
+: "${hist_file:="$cache_dir/watch_hist"}" "${search_hist_file:="$cache_dir/search_hist"}"
 
 # Where do we put the list of healthy instances?
 : "${instances_file:="$cache_dir/instances.json"}"
 
+# URL for instance list sorted by type, health and api (ones without API do not work!)
+instances_url="https://api.invidious.io/instances.json?sort_by=type,health,api"
+
 # If file doesn't already exist (or if force-refresh is requested), cURL and cache it.
 # CHECK: implement check for force-request
 # CHECK: added --refresh-inv-instances to optargs
-# TODO: update docs
 [ ! -f "$instances_file" ] ||
     [ "$refresh_inv_instances" -eq 1 ] &&
     print_info "Fetching list of healthy invidious instances ...\n" &&

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="git-1698.cd09e5e"
+YTFZF_VERSION="git-1699.5af0c73"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID
@@ -795,13 +795,36 @@ _thread_started (){
 }
 
 _get_real_channel_link () {
-	domain=${1#https://}
-	domain=${domain%%/*}
-	url=$(printf "%s" "$1" | sed 's_\(https://\)*\(www\.\)*youtube\.com_'"${invidious_instance}"'_')
+    case "$1" in
+        https://*|*\.*)
+            domain=${1#https://}
+            domain=${domain%%/*}
+            url=$(printf "%s" "$1" | sed 's_\(https://\)*\(www\.\)*youtube\.com_'"${invidious_instance}"'_')
+            _get_real_channel_link_handle_empty_real_path () {
+                 printf "https://%s\n" "${1#https://}"
+            } ;;
+        [Uu][Cc]??????????????????????/videos|[Uu][Cc]??????????????????????|*channel/[Uu][Cc]??????????????????????|*channel/[Uu][Cc]??????????????????????/videos)
+            id="${1%/videos}"
+            id="${id##*channel/}"
+            print_warning "$1 appears to be a youtube id, which is hard to detect, please use a full channel url next time\n"
+            domain="youtube.com"
+            url=$(printf "https://youtube.com/channel/%s/videos" "$id" | sed 's_\(https://\)*\(www\.\)*youtube\.com_'"${invidious_instance}"'_')
+            _get_real_channel_link_handle_empty_real_path () {
+                printf "%s\n" "https://${domain}/channel/${id}/videos"
+            } ;;
+        *)
+            _get_real_channel_link_handle_empty_real_path(){
+                printf "$1\n"
+            } ;;
+    esac
+
 	real_path="$(curl -is "$url" | sed -n 's/^[Ll]ocation: //p' | sed 's/[\n\r]$//g')"
 	#prints the origional url because it was correct
-	[ -z "$real_path" ] && printf "%s\n" "$1" && return 0
-	printf "%s\n" "https://${domain}${real_path}"
+    if [ -z "$real_path" ]; then
+        _get_real_channel_link_handle_empty_real_path "$1"
+        return 0
+    fi
+    printf "%s\n" "https://${domain}${real_path}"
 }
 
 set_real_channel_url_and_id () {
@@ -901,10 +924,11 @@ scrape_youtube_channel () {
 	channel_url="$1"
     [ "$channel_url" = ":help" ] && print_info "The search should be a link to a youtube channel\n" && return 100
 	output_json_file="$2"
-	print_info "Scraping Youtube channel: $channel_url\n"
 
 
 	set_real_channel_url_and_id "$channel_url"
+
+	print_info "Scraping Youtube channel: https://www.youtube.com/channel/${channel_id}/videos\n"
 
 	tmp_filename="channel-${channel_id}"
 	_tmp_html="${session_temp_dir}/${tmp_filename}.html"
@@ -2221,7 +2245,9 @@ parse_opt () {
         type) search_result_type=$optarg ;;
         features) search_result_features=$optarg ;;
         region) search_region=$optarg ;;
-        channel-link) _get_real_channel_link "$optarg"; exit 0 ;;
+        channel-link)
+            invidious_instance=$(get_invidious_instances | shuf | head -n 1)
+            _get_real_channel_link "$optarg"; exit 0 ;;
         available-inv-instances) get_invidious_instances; exit 0 ;;
         disable-submenus) enable_submenus="${optarg:-0}" ;;
         thumbnail-quality) thumbnail_quality="$optarg" ;;


### PR DESCRIPTION
![MAGIC MODELINES](https://media.giphy.com/media/f5BwvEFBcgzU4/giphy.gif)

I noticed the Vim modeline was not working. I checked all my settings locally and sure enough, it wasn't being picked up because of a single space after the comment `#`. 

According to [the docs for Vim modelines](https://vimdoc.sourceforge.net/htmldoc/options.html#modeline), the space following `vim:` is optional, but the one preceding it is not. This should ensure proper detection.

This PR adds not only the required space, but goes ONE STEP FURTHER, and adds an *optional* one following the colon. This is avandt-garde code styling, I KNOW. FWIW the help doc provides an example of each, with and without the trailing space after the colon.

Additionally, modelines are a known security vulnerability. Consider removing it to protect users running a version less than `8.1.1365`.  A lot of distributions have it disabled by default. Debian adds explicit warnings. More [here](https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md) if you are interested.
