### PR TITLE
Add required whitespace to vim modeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,8 @@ assignees: ''
  - OS:
  - Terminal:
  - Ytfzf version:
-- Output of `ls -l "$(which sh)"` (if your using fish: `ls -l (which sh)`):
+- Output of `ls -l "$(which sh)"` (if you're using fish: `ls -l (which sh)`):
+ - (if is a thumbnail issue) run `ytfzf --thumbnail-log=log.txt` and post the file:
 
 
 ### Additional context

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,11 @@ LICENSEDIR=${PREFIX}/share/licenses/ytfzf
 
 YTFZF_SYSTEM_ADDON_DIR=${PREFIX}/share/ytfzf/addons
 
+.DEFAULT_GOAL := default
+
 all:
+
+default: install doc
 
 doc:
 	mkdir -p ${DESTDIR}${MANDIR}/man1

--- a/ytfzf
+++ b/ytfzf
@@ -2590,4 +2590,4 @@ while [ "$search_again" -eq 1 ] ; do
 done
 #}}}
 
-#vim:foldmethod=marker:shiftwidth=4:tabstop=4
+# vim: foldmethod=marker:shiftwidth=4:tabstop=4

--- a/ytfzf
+++ b/ytfzf
@@ -2,7 +2,7 @@
 
 #versioning system:
 #major.minor.bugs
-YTFZF_VERSION="git-1701.099ba9a"
+YTFZF_VERSION="git-1701.6de5a82"
 
 # Scraping: query -> video json
 # User Interface: video json -> user selection -> ID


### PR DESCRIPTION
![MAGIC MODELINES](https://media.giphy.com/media/f5BwvEFBcgzU4/giphy.gif)

I noticed the Vim modeline was not working. I checked all my settings locally and sure enough, it wasn't being picked up because of a single space after the comment `#`. 

According to [the docs for Vim modelines](https://vimdoc.sourceforge.net/htmldoc/options.html#modeline), the space following `vim:` is optional, but the one preceding it is not. This should ensure proper detection.

This PR adds not only the required space, but goes ONE STEP FURTHER, and adds an *optional* one following the colon. This is avandt-garde code styling, I KNOW. FWIW the help doc provides an example of each, with and without the trailing space after the colon.

Additionally, modelines are a known security vulnerability. Consider removing it to protect users running a version less than `8.1.1365`.  A lot of distributions have it disabled by default. Debian adds explicit warnings. More [here](https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md) if you are interested.
