### PR TITLE
Fix spelling in docs/man/ytfzf.5

### DIFF
--- a/docs/man/ytfzf.5
+++ b/docs/man/ytfzf.5
@@ -2141,7 +2141,7 @@ The thumbnail viewer to load
 .TP
 .BR _get_request ()
 This function sends a request to a server and prints the response.
-This funciton takes Unlimited arguments.
+This function takes Unlimited arguments.
 .RS
 .TP
 .I 1


### PR DESCRIPTION
Follows fix spelling in the manual file docs/man/ytfzf.5 according to the packaging in Debian, because I am the maintainer of the package in Debian.