### PR TITLE
fix 'else if' jq syntax for `invidious-channel` scraper

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -2053,7 +2053,7 @@ scrape_invidious_channel () {
 
         _get_request "${channel_url##* }" \
             -G --data-urlencode "page=$_cur_page" \
-            | jq 'if (.videos|type) == "array" then .videos else if (.latestVideos|type) == "array" then .latestVideos end end' \
+            | jq 'if (.videos|type) == "array" then .videos elif (.latestVideos|type) == "array" then .latestVideos else null end' \
             | _invidious_search_json_generic "invidious_channel" \
             | jq 'select(.!=[])' >> "$output_json_file" || return "$?"
     done


### PR DESCRIPTION
Similar to [this commit](https://github.com/pystardust/ytfzf/commit/f600bb678341de3f0742c9758c2f7234b887488a) that resolved #646 .  Resolves the same issue for the `invidious-channel` scraper.

This is the only other instance of a jq "else if" that I could find.