### PR TITLE
fix: fzf ignores  FZF_DEFAULT_OPTS if not exported

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -407,7 +407,7 @@ on_post_set_vars___ytfzf__ () {
 
     : "${invidious_instance:=$(get_random_invidious_instance)}"
 
-    FZF_DEFAULT_OPTS="--margin=0,3,0,0 $FZF_DEFAULT_OPTS"
+    export FZF_DEFAULT_OPTS="--margin=0,3,0,0 $FZF_DEFAULT_OPTS"
 
 
     [ "$multi_search" -eq 1 ] && load_fake_extension "__ytfzf_multisearch__"


### PR DESCRIPTION
The workaround introduced in 468d5d9850 for setting the right-side margins for `fzf` via prepending to `FZF_DEFAULT_OPTS` only gets propagated to subsequent invocations of `fzf` if the `FZF_DEFAULT_OPTS` is exported by the caller in the first place. (Re-)exporting the variable works in both situations.