### PR TITLE
ytfzf: fixed syntax errors inside of command substitutions

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -3038,14 +3038,14 @@ get_video_format_simple () {
 get_video_format(){
 	# the sed gets rid of random information
     _audio_choices=$(case "$YTDL_EXEC_NAME" in
-        youtube-dl) ${ytdl_path} -F "$1" ;;
-        *) ${ytdl_path} -q -F "$1" --format-sort "$format_selection_sort"
+	(youtube-dl) ${ytdl_path} -F "$1" ;;
+        (*) ${ytdl_path} -q -F "$1" --format-sort "$format_selection_sort"
     esac | grep 'audio only')
     [ "$_audio_choices" ] && audio_pref="$(echo "$_audio_choices" | quick_menu_wrapper "Audio format: " | awk '{print $1}')"
     if [ "$is_audio_only" -eq 0 ]; then
         video_pref=$(case "$YTDL_EXEC_NAME" in
-            youtube-dl) ${ytdl_path} -F "$1" | sed 1,3d;;
-            *) ${ytdl_path} -q -F "$1" --format-sort "$format_selection_sort" : ;;
+            (youtube-dl) ${ytdl_path} -F "$1" | sed 1,3d;;
+            (*) ${ytdl_path} -q -F "$1" --format-sort "$format_selection_sort" : ;;
         esac |  sed 's/\\033\[[[:digit:]]*m//g' | grep -v 'audio only' | quick_menu_wrapper "Video Format: "| awk '{print $1}')
     fi
     ytdl_pref="${video_pref}+${audio_pref}/${video_pref}/${audio_pref}"


### PR DESCRIPTION
On macos, /bin/sh doesn't handle case statements in $(...) command
substitutions unless parens are properly paired up.
