### PR TITLE
Fix "multi" scraper invocation via short name

### DIFF
--- a/credits/gardockt.md
+++ b/credits/gardockt.md
@@ -1,3 +1,3 @@
 # Gardockt
 
-* Fixed `add_commas` so that it actually gives correct numbers
+* Various bugfixes

--- a/ytfzf
+++ b/ytfzf
@@ -2165,7 +2165,7 @@ Eg:
 	unset PARENT_invidious_instance PARENT_OUTPUT_JSON_FILE
 	return 0
 }
-scrrape_M() { scrape_multi "$@"; }
+scrape_M() { scrape_multi "$@"; }
 ## }}}
 
 ## Peertube {{{


### PR DESCRIPTION
Trying to invoke `M` scraper (for example, with a command `ytfzf -c M :help`) results in `command not found` error, as a result of a typo in `scrape_M` function name.