### PR TITLE
Fix modifiers in scrape_invidious_channel

### DIFF
--- a/ytfzf
+++ b/ytfzf
@@ -2115,12 +2115,26 @@ scrape_invidious_channel() {
 
 		print_info "Scraping Youtube (with $invidious_instance) channel: $channel_url${new_line}"
 
+		case "$modifier" in
+			streams)
+				__jq_filter='.streams? // []'
+				__jq_parser=_invidious_search_json_live
+				;;
+			playlists)
+				__jq_filter='.playlists? // []'
+				__jq_parser=_invidious_search_json_playlist
+				;;
+			videos|*)
+				__jq_filter='(.videos? // []) + (.latestVideos? // [])'
+				__jq_parser=_invidious_search_json_generic
+				;;
+		esac
+
 		_get_invidious_thumb_quality_name
 
 		_get_request "${channel_url##* }" \
-			-G --data-urlencode "page=$_cur_page" |
-			jq 'if (.videos|type) == "array" then .videos elif (.latestVideos|type) == "array" then .latestVideos else null end' |
-			_invidious_search_json_generic "invidious_channel" |
+				-G --data-urlencode "page=$_cur_page" |
+			jq "$__jq_filter" | $__jq_parser "invidious_channel" |
 			jq 'select(.!=[])' >>"$output_json_file" || return "$?"
 	done
 }

--- a/ytfzf
+++ b/ytfzf
@@ -3586,15 +3586,18 @@ handle_scraping() {
 	prepare_for_set_args ","
 	# if there is only 1 scraper used, multi search is on, then multiple searches will be performed seperated by ,
 	__scrape_count=0
+	__ret=0
 	for curr_scrape in $scrape; do
 		__scrape_count=$((__scrape_count + 1))
 		do_an_event_function "ext_on_search" "$_search" "$curr_scrape"
 		command_exists "on_search_$_search" && "on_search_$_search" "$curr_scrape"
-		if ! "scrape_$(printf '%s' "$curr_scrape" | sed 's/-/_/g')" "$_search" "$ytfzf_video_json_file"; then
-			handle_scrape_error "$?" "$curr_scrape"
+		"scrape_$(printf '%s' "$curr_scrape" | sed 's/-/_/g')" "$_search" "$ytfzf_video_json_file"
+		__ret=$?
+		if [ $__ret != 0 ]; then
+			handle_scrape_error $__ret "$curr_scrape"
 		fi
 	done
-	[ "$?" -eq 100 ] && exit 0
+	[ $? -eq 100 ] && exit 0
 	end_of_set_args
 }
 


### PR DESCRIPTION
To allow a `cmd` like `ytfzf --type=channel --submenu-opts="--type=all"`

Also do not swallow the return code of the call `ytfzf :help`
